### PR TITLE
Basic pagination for block events table

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -6,16 +6,17 @@ export async function GET(req: Request) {
     const pageParam = url.searchParams.get("page")?.trim() ?? "";
 
     // TODO
-    // - [ ] make this a validator, too.
     // - [ ] config limit variable
-    const pageOffset = (parseInt(pageParam, 10) - 1) * 10;
+    const pageOffset = (parseInt(pageParam, 10)) * 10;
 
-    const blockEvents = await db.blocks.findMany({
-      where: {
-        tx_results: {
-          some: {},
-        },
+    const where = {
+      tx_results: {
+        some: {},
       },
+    };
+
+    const events = db.blocks.findMany({
+      where,
       select: {
         height: true,
         created_at: true,
@@ -32,7 +33,26 @@ export async function GET(req: Request) {
       },
     });
 
-    return new Response(JSON.stringify(blockEvents));
+    // In moments like this, I truly miss rolling plain SQL.
+    // PrismaJS's docs on pagination are... "untruthful" because it is actually impossible to get the count for a pagination's count within the query.
+    // Instead, we need to make two separate queries to first count all rows that match the criteria of our filter. After we acquire that number, we then run the query that gives us the actual rows using that same filter.
+    // This is done in Promise.all() becuase Prisma's transaction method runs sequentially.
+    // We cannot do both of these in a single query.
+    // See:
+    // - https://github.com/prisma/prisma/discussions/16148
+    // - https://github.com/prisma/prisma/issues/6570
+    // - https://github.com/prisma/prisma/issues/7550
+    const [count, blockEvents] = await Promise.all([
+      db.blocks.count({
+        where,
+      }),
+      events,
+    ]);
+
+    // Ensure that our pagination doesn't cut off early.
+    const pages = Math.floor((count / 10) + 1);
+
+    return new Response(JSON.stringify([pages, blockEvents]));
   } catch (error) {
     return new Response("Could not load events.", { status: 404 });
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,34 +1,10 @@
 import EventTable from "@/components/EventTable";
-import { TableEvents } from "@/lib/validators/table";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
-import axios from "axios";
 
 export default async function Home() {
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery({
-    queryKey: ["eventTableQuery"],
-    queryFn: async () => {
-      const { data } = await axios.get(`/api/events?page=${1}`);
-      const result = TableEvents.safeParse(data);
-      if (result.success) {
-        return result.data;
-      } else {
-        // NOTE: another reason to move this hydration further down the component tree, ie create a completely generic data-table component and
-        //       make independent BlockEventTable/TransactionEventTable server generated components that performs the hydration, is that
-        //       it will allow for toaster errors without losing access to static server rendering.
-        //       It's that or going back to react-hot-toast which provides a headless UI solution for this precise issue.
-        throw new Error(result.error.message);
-      }
-    },
-    meta: {
-      errorMessage: "Failed to query data while trying to generate event table, please try reloading the page.",
-    },
-  });
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <div>
       <EventTable />
-    </HydrationBoundary>
+    </div>
   );
 }

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -4,7 +4,6 @@ import {
   type ColumnDef,
   flexRender,
   getCoreRowModel,
-  getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
  
@@ -17,24 +16,22 @@ import {
   TableRow,
 } from "@/components/ui/Table";
 
-import { Button } from "@/components/ui/button";
-
 interface DataTableProps<TData, TValue> {
   columns: Array<ColumnDef<TData, TValue>>
-  data: TData[]
+  data: TData[],
 }
  
 export function DataTable<TData, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
+
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
   });
- 
+
   return (
     <div>
       <div className="rounded-md border">
@@ -81,24 +78,6 @@ export function DataTable<TData, TValue>({
             )}
           </TableBody>
         </Table>
-      </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {table.previousPage()}}
-          disabled={!table.getCanPreviousPage()}
-        >
-          Previous
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {table.nextPage()}}
-          disabled={!table.getCanNextPage()}
-        >
-          Next
-        </Button>
       </div>
     </div>
   );

--- a/src/components/ui/paginated-data-table.tsx
+++ b/src/components/ui/paginated-data-table.tsx
@@ -1,0 +1,151 @@
+"use client";
+ 
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type PaginationState,
+} from "@tanstack/react-table";
+ 
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/Table";
+
+import { Button } from "@/components/ui/button";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import { TableEvents } from "@/lib/validators/table";
+
+interface PaginatedDataTableProps<TData, TValue> {
+  columns: Array<ColumnDef<TData, TValue>>
+  queryK: string,
+}
+ 
+export function PaginatedDataTable<TData, TValue>({
+  columns,
+  queryK,
+}: PaginatedDataTableProps<TData, TValue>) {
+
+  const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const queryOptions = {
+    pageIndex,
+    pageSize,
+  };
+
+  const { data } = useQuery({
+    queryKey: [queryK, queryOptions],
+    queryFn: async () => {
+      const { data } = await axios.get(`/api/events?page=${pageIndex}`);
+      const result = TableEvents.safeParse(data);
+      if (result.success) {
+        return result.data;
+      } else {
+        throw new Error(result.error.message);
+      }
+    },
+    meta: {
+      errorMessage: "Failed to query paginated data to populate table. Please try again.",
+    },
+  });
+
+  const [pageCount, eventData] = data ?? [0, []];
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize,
+    }),
+    [pageIndex, pageSize],
+  );
+
+  const table = useReactTable({
+    data: eventData as TData[],
+    columns,
+    pageCount,
+    state: {
+      pagination,
+    },
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
+
+  return (
+    <div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader className="bg-slate-200">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  className="bg-white"
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {table.previousPage()}}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {table.nextPage()}}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+     </div>
+  );
+}

--- a/src/lib/validators/table.ts
+++ b/src/lib/validators/table.ts
@@ -1,11 +1,16 @@
 import { z } from "zod";
 
-export const TableEvents = z.array(z.object({
-  height: z.coerce.bigint(),
-  created_at: z.string().datetime(),
-  tx_results: z.array(z.object({
-    tx_hash: z.string(),
-    })),
-}));
+export const TableEvents = z.tuple([
+  z.number(),
+  z.array(
+    z.object({
+      height: z.coerce.bigint(),
+      created_at: z.string().datetime(),
+      tx_results: z.array(z.object({
+        tx_hash: z.string(),
+      })),
+    }),
+  ),
+]);
 
 export type TableEventsPayload = z.infer<typeof TableEvents>;


### PR DESCRIPTION
Broke out the data table component into two versions, the original and a paginated version and moved data queries further down the component tree. This makes `EventTable` a server component, which better leverages server hydration, but this refactoring will also make it easier to break out different table views.

Besides adding additional table views, future work would include changing pagination to cursors instead of offsets for performance. 