### PR TITLE
build: use "pnpm dev" as container run cmd

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,4 +15,4 @@ RUN pnpm build
 
 # Run.
 EXPOSE 3000
-CMD [ "pnpm", "start" ]
+CMD [ "pnpm", "dev" ]


### PR DESCRIPTION
When writing the Containerfile for this app, I mistakenly used "pnpm start" as the container entrypoint. I'm not sure what that command does, but it doesn't seem to start the app. Instead, let's use "pnpm dev", the same as used during local development (and which we observed working in a hosted environment, as well).