### PR TITLE
JSON rendering for `Transaction` (aka `TxResult.body`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,14 @@
       "name": "cuiloa",
       "version": "0.1.0",
       "dependencies": {
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.4.2-20231127085224-6462d33db553.1",
+        "@buf/cosmos_cosmos-sdk.connectrpc_es": "^1.1.3-20231127085224-6462d33db553.1",
+        "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.4.2-20231120132728-bc443669626d.1",
+        "@buf/penumbra-zone_penumbra.connectrpc_es": "^1.1.3-20231120132728-bc443669626d.1",
+        "@buf/penumbra-zone_penumbra.connectrpc_query-es": "^0.6.0-20231120132728-bc443669626d.2",
+        "@bufbuild/protobuf": "^1.4.2",
+        "@connectrpc/connect": "^1.1.3",
+        "@microlink/react-json-view": "^1.23.0",
         "@prisma/client": "^5.4.1",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
@@ -77,6 +85,971 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.2-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.2-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-proto.connectrpc_es": {
+      "version": "1.1.3-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.connectrpc_es/-/cosmos_cosmos-proto.connectrpc_es-1.1.3-20211202220400-1935555c206d.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-proto.connectrpc_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.1-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.1-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-proto.connectrpc_query-es": {
+      "version": "0.6.0-20211202220400-1935555c206d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.connectrpc_query-es/-/cosmos_cosmos-proto.connectrpc_query-es-0.6.0-20211202220400-1935555c206d.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-proto.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.0-20211202220400-1935555c206d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.0-20211202220400-1935555c206d.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.2-20231127085224-6462d33db553.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.2-20231127085224-6462d33db553.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.2-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.2-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.2-20230822184711-28151c0d0a16.1",
+        "@buf/protocolbuffers_wellknowntypes.bufbuild_es": "1.4.2-20230509212704-657250e6a396.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.2-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.2-20230509103710-5e5b9fdd0180.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.2-20230822184711-28151c0d0a16.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.2-20230822184711-28151c0d0a16.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es": {
+      "version": "1.1.3-20231127085224-6462d33db553.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.1.3-20231127085224-6462d33db553.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_es": "1.1.3-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20231127085224-6462d33db553.1",
+        "@buf/cosmos_gogo-proto.connectrpc_es": "1.1.3-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.1.3-20230822184711-28151c0d0a16.1",
+        "@buf/protocolbuffers_wellknowntypes.connectrpc_es": "1.1.3-20230509212704-657250e6a396.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.1-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.1-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.1-20231127085224-6462d33db553.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.1-20231127085224-6462d33db553.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20230822184711-28151c0d0a16.1",
+        "@buf/protocolbuffers_wellknowntypes.bufbuild_es": "1.4.1-20230509212704-657250e6a396.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20230509103710-5e5b9fdd0180.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.connectrpc_es": {
+      "version": "1.1.3-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.1.3-20230509103710-5e5b9fdd0180.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20230509103710-5e5b9fdd0180.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20230822184711-28151c0d0a16.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20230822184711-28151c0d0a16.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/googleapis_googleapis.connectrpc_es": {
+      "version": "1.1.3-20230822184711-28151c0d0a16.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.1.3-20230822184711-28151c0d0a16.1.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20230822184711-28151c0d0a16.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/protocolbuffers_wellknowntypes.bufbuild_es": {
+      "version": "1.4.1-20230509212704-657250e6a396.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/protocolbuffers_wellknowntypes.bufbuild_es/-/protocolbuffers_wellknowntypes.bufbuild_es-1.4.1-20230509212704-657250e6a396.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es": {
+      "version": "0.6.0-20230522115704-e7a85cef453e.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_query-es/-/cosmos_cosmos-sdk.connectrpc_query-es-0.6.0-20230522115704-e7a85cef453e.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_query-es": "0.6.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.0-20230522115704-e7a85cef453e.2",
+        "@buf/cosmos_gogo-proto.connectrpc_query-es": "0.6.0-20221020125208-34d970b699f8.2",
+        "@buf/googleapis_googleapis.connectrpc_query-es": "0.6.0-20221214150216-75b4300737fb.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.0-20211202220400-1935555c206d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.0-20211202220400-1935555c206d.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.0-20230522115704-e7a85cef453e.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.0-20230522115704-e7a85cef453e.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20221214150216-75b4300737fb.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20221020125208-34d970b699f8.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20221020125208-34d970b699f8.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20221214150216-75b4300737fb.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20221214150216-75b4300737fb.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.2-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.2-20221020125208-34d970b699f8.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_gogo-proto.connectrpc_es": {
+      "version": "1.1.3-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.1.3-20221020125208-34d970b699f8.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20221020125208-34d970b699f8.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_gogo-proto.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20221020125208-34d970b699f8.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_gogo-proto.connectrpc_query-es": {
+      "version": "0.6.0-20221020125208-34d970b699f8.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_query-es/-/cosmos_gogo-proto.connectrpc_query-es-0.6.0-20221020125208-34d970b699f8.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_gogo-proto.connectrpc_query-es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20221020125208-34d970b699f8.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20221020125208-34d970b699f8.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.bufbuild_es": {
+      "version": "1.4.2-20230913112312-7ab44ae956a0.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.4.2-20230913112312-7ab44ae956a0.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.2-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.2-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.2-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.2-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.2-20220908150232-8d7204855ec1.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.2-20230719110346-aa25660f4ff7.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.2-20230719110346-aa25660f4ff7.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.2-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.2-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.2-20230502210827-cc916c318597.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.2-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.2-20230509103710-5e5b9fdd0180.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.2-20230502210827-cc916c318597.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.2-20230502210827-cc916c318597.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.2-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.2-20220908150232-8d7204855ec1.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es": {
+      "version": "1.1.3-20230913112312-7ab44ae956a0.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_es/-/cosmos_ibc.connectrpc_es-1.1.3-20230913112312-7ab44ae956a0.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_es": "1.1.3-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.connectrpc_es": "1.1.3-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.connectrpc_es": "1.1.3-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ibc.bufbuild_es": "1.4.1-20230913112312-7ab44ae956a0.1",
+        "@buf/cosmos_ics23.connectrpc_es": "1.1.3-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.1.3-20220908150232-8d7204855ec1.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.1-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.1-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.1-20230719110346-aa25660f4ff7.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.1-20230719110346-aa25660f4ff7.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20230502210827-cc916c318597.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es": {
+      "version": "1.1.3-20230719110346-aa25660f4ff7.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.1.3-20230719110346-aa25660f4ff7.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_es": "1.1.3-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.connectrpc_es": "1.1.3-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.1.3-20230502210827-cc916c318597.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.connectrpc_es": {
+      "version": "1.1.3-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_es/-/cosmos_gogo-proto.connectrpc_es-1.1.3-20230509103710-5e5b9fdd0180.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20230509103710-5e5b9fdd0180.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es/node_modules/@buf/googleapis_googleapis.connectrpc_es": {
+      "version": "1.1.3-20230502210827-cc916c318597.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.1.3-20230502210827-cc916c318597.1.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20230502210827-cc916c318597.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20230509103710-5e5b9fdd0180.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es": {
+      "version": "1.4.1-20230913112312-7ab44ae956a0.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.4.1-20230913112312-7ab44ae956a0.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.1-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20220908150232-8d7204855ec1.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20221020125208-34d970b699f8.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20220908150232-8d7204855ec1.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.1-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.1-20221207100654-55085f7c710a.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20230502210827-cc916c318597.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20230502210827-cc916c318597.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/googleapis_googleapis.connectrpc_es": {
+      "version": "1.1.3-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.1.3-20220908150232-8d7204855ec1.1.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20220908150232-8d7204855ec1.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_es/node_modules/@buf/googleapis_googleapis.connectrpc_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20220908150232-8d7204855ec1.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es": {
+      "version": "0.6.0-20230913112312-7ab44ae956a0.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.connectrpc_query-es/-/cosmos_ibc.connectrpc_query-es-0.6.0-20230913112312-7ab44ae956a0.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_query-es": "0.6.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.connectrpc_query-es": "0.6.0-20230719110346-aa25660f4ff7.2",
+        "@buf/cosmos_gogo-proto.connectrpc_query-es": "0.6.0-20221020125208-34d970b699f8.2",
+        "@buf/cosmos_ibc.bufbuild_es": "1.4.0-20230913112312-7ab44ae956a0.2",
+        "@buf/cosmos_ics23.connectrpc_query-es": "0.6.0-20221207100654-55085f7c710a.2",
+        "@buf/googleapis_googleapis.connectrpc_query-es": "0.6.0-20220908150232-8d7204855ec1.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.0-20211202220400-1935555c206d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.0-20211202220400-1935555c206d.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.0-20230719110346-aa25660f4ff7.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.0-20230719110346-aa25660f4ff7.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20230509103710-5e5b9fdd0180.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20230502210827-cc916c318597.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es": {
+      "version": "0.6.0-20230719110346-aa25660f4ff7.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_query-es/-/cosmos_cosmos-sdk.connectrpc_query-es-0.6.0-20230719110346-aa25660f4ff7.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_query-es": "0.6.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.0-20230719110346-aa25660f4ff7.2",
+        "@buf/cosmos_gogo-proto.connectrpc_query-es": "0.6.0-20230509103710-5e5b9fdd0180.2",
+        "@buf/googleapis_googleapis.connectrpc_query-es": "0.6.0-20230502210827-cc916c318597.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/cosmos_gogo-proto.connectrpc_query-es": {
+      "version": "0.6.0-20230509103710-5e5b9fdd0180.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.connectrpc_query-es/-/cosmos_gogo-proto.connectrpc_query-es-0.6.0-20230509103710-5e5b9fdd0180.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20230509103710-5e5b9fdd0180.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.connectrpc_query-es": {
+      "version": "0.6.0-20230502210827-cc916c318597.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_query-es/-/googleapis_googleapis.connectrpc_query-es-0.6.0-20230502210827-cc916c318597.2.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20230502210827-cc916c318597.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20230509103710-5e5b9fdd0180.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20230509103710-5e5b9fdd0180.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es": {
+      "version": "1.4.0-20230913112312-7ab44ae956a0.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.4.0-20230913112312-7ab44ae956a0.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.0-20230719110346-aa25660f4ff7.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.0-20221207100654-55085f7c710a.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20220908150232-8d7204855ec1.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20221020125208-34d970b699f8.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20221020125208-34d970b699f8.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20220908150232-8d7204855ec1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20220908150232-8d7204855ec1.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.0-20221207100654-55085f7c710a.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.0-20221207100654-55085f7c710a.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20230502210827-cc916c318597.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20230502210827-cc916c318597.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.connectrpc_query-es": {
+      "version": "0.6.0-20220908150232-8d7204855ec1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_query-es/-/googleapis_googleapis.connectrpc_query-es-0.6.0-20220908150232-8d7204855ec1.2.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20220908150232-8d7204855ec1.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ibc.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20220908150232-8d7204855ec1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20220908150232-8d7204855ec1.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.2-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.2-20221207100654-55085f7c710a.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/cosmos_ics23.connectrpc_es": {
+      "version": "1.1.3-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.connectrpc_es/-/cosmos_ics23.connectrpc_es-1.1.3-20221207100654-55085f7c710a.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.1-20221207100654-55085f7c710a.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/cosmos_ics23.connectrpc_es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.1-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.1-20221207100654-55085f7c710a.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/cosmos_ics23.connectrpc_query-es": {
+      "version": "0.6.0-20221207100654-55085f7c710a.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.connectrpc_query-es/-/cosmos_ics23.connectrpc_query-es-0.6.0-20221207100654-55085f7c710a.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.0-20221207100654-55085f7c710a.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/cosmos_ics23.connectrpc_query-es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.0-20221207100654-55085f7c710a.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.0-20221207100654-55085f7c710a.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.2-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.2-20221214150216-75b4300737fb.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.connectrpc_es": {
+      "version": "1.1.3-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_es/-/googleapis_googleapis.connectrpc_es-1.1.3-20221214150216-75b4300737fb.1.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.connectrpc_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20221214150216-75b4300737fb.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.connectrpc_query-es": {
+      "version": "0.6.0-20221214150216-75b4300737fb.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.connectrpc_query-es/-/googleapis_googleapis.connectrpc_query-es-0.6.0-20221214150216-75b4300737fb.2.tgz",
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20221214150216-75b4300737fb.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/googleapis_googleapis.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20221214150216-75b4300737fb.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20221214150216-75b4300737fb.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es": {
+      "version": "1.4.2-20231120132728-bc443669626d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.4.2-20231120132728-bc443669626d.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.2-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.2-20230522115704-e7a85cef453e.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.2-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ibc.bufbuild_es": "1.4.2-20230913112312-7ab44ae956a0.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.2-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.2-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.2-20230522115704-e7a85cef453e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.2-20230522115704-e7a85cef453e.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.2-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.2-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.2-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es": {
+      "version": "1.1.3-20231120132728-bc443669626d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_es/-/penumbra-zone_penumbra.connectrpc_es-1.1.3-20231120132728-bc443669626d.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_es": "1.1.3-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.connectrpc_es": "1.1.3-20230522115704-e7a85cef453e.1",
+        "@buf/cosmos_gogo-proto.connectrpc_es": "1.1.3-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ibc.connectrpc_es": "1.1.3-20230913112312-7ab44ae956a0.1",
+        "@buf/cosmos_ics23.connectrpc_es": "1.1.3-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.1.3-20221214150216-75b4300737fb.1",
+        "@buf/penumbra-zone_penumbra.bufbuild_es": "1.4.1-20231120132728-bc443669626d.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.1-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.1-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.1-20230522115704-e7a85cef453e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.1-20230522115704-e7a85cef453e.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_cosmos-sdk.connectrpc_es": {
+      "version": "1.1.3-20230522115704-e7a85cef453e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.connectrpc_es/-/cosmos_cosmos-sdk.connectrpc_es-1.1.3-20230522115704-e7a85cef453e.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_es": "1.1.3-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20230522115704-e7a85cef453e.1",
+        "@buf/cosmos_gogo-proto.connectrpc_es": "1.1.3-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.connectrpc_es": "1.1.3-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20221020125208-34d970b699f8.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es": {
+      "version": "1.4.1-20230913112312-7ab44ae956a0.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.4.1-20230913112312-7ab44ae956a0.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.1-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20220908150232-8d7204855ec1.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.1-20230719110346-aa25660f4ff7.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.1-20230719110346-aa25660f4ff7.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20230502210827-cc916c318597.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.1-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.1-20230509103710-5e5b9fdd0180.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20230502210827-cc916c318597.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20230502210827-cc916c318597.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20220908150232-8d7204855ec1.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.1-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.1-20221207100654-55085f7c710a.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.1-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.1-20221214150216-75b4300737fb.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_es/node_modules/@buf/penumbra-zone_penumbra.bufbuild_es": {
+      "version": "1.4.1-20231120132728-bc443669626d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.4.1-20231120132728-bc443669626d.1.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.1-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.1-20230522115704-e7a85cef453e.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.1-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ibc.bufbuild_es": "1.4.1-20230913112312-7ab44ae956a0.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.1-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.1-20221214150216-75b4300737fb.1"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es": {
+      "version": "0.6.0-20231120132728-bc443669626d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.connectrpc_query-es/-/penumbra-zone_penumbra.connectrpc_query-es-0.6.0-20231120132728-bc443669626d.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.connectrpc_query-es": "0.6.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.connectrpc_query-es": "0.6.0-20230522115704-e7a85cef453e.2",
+        "@buf/cosmos_gogo-proto.connectrpc_query-es": "0.6.0-20221020125208-34d970b699f8.2",
+        "@buf/cosmos_ibc.connectrpc_query-es": "0.6.0-20230913112312-7ab44ae956a0.2",
+        "@buf/cosmos_ics23.connectrpc_query-es": "0.6.0-20221207100654-55085f7c710a.2",
+        "@buf/googleapis_googleapis.connectrpc_query-es": "0.6.0-20221214150216-75b4300737fb.2",
+        "@buf/penumbra-zone_penumbra.bufbuild_es": "1.4.0-20231120132728-bc443669626d.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0",
+        "@connectrpc/connect-query": "^0.6.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.4.0-20211202220400-1935555c206d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.4.0-20211202220400-1935555c206d.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.0-20230522115704-e7a85cef453e.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.0-20230522115704-e7a85cef453e.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20221214150216-75b4300737fb.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20221020125208-34d970b699f8.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20221020125208-34d970b699f8.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es": {
+      "version": "1.4.0-20230913112312-7ab44ae956a0.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.4.0-20230913112312-7ab44ae956a0.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.0-20230719110346-aa25660f4ff7.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.0-20221207100654-55085f7c710a.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20220908150232-8d7204855ec1.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
+      "version": "1.4.0-20230719110346-aa25660f4ff7.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.4.0-20230719110346-aa25660f4ff7.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20230509103710-5e5b9fdd0180.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20230502210827-cc916c318597.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.4.0-20230509103710-5e5b9fdd0180.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.4.0-20230509103710-5e5b9fdd0180.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20230502210827-cc916c318597.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20230502210827-cc916c318597.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20220908150232-8d7204855ec1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20220908150232-8d7204855ec1.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.4.0-20221207100654-55085f7c710a.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.4.0-20221207100654-55085f7c710a.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.4.0-20221214150216-75b4300737fb.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.4.0-20221214150216-75b4300737fb.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.connectrpc_query-es/node_modules/@buf/penumbra-zone_penumbra.bufbuild_es": {
+      "version": "1.4.0-20231120132728-bc443669626d.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.4.0-20231120132728-bc443669626d.2.tgz",
+      "dependencies": {
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.4.0-20211202220400-1935555c206d.2",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.4.0-20230522115704-e7a85cef453e.2",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.4.0-20221020125208-34d970b699f8.2",
+        "@buf/cosmos_ibc.bufbuild_es": "1.4.0-20230913112312-7ab44ae956a0.2",
+        "@buf/cosmos_ics23.bufbuild_es": "1.4.0-20221207100654-55085f7c710a.2",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.4.0-20221214150216-75b4300737fb.2"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/protocolbuffers_wellknowntypes.bufbuild_es": {
+      "version": "1.4.2-20230509212704-657250e6a396.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/protocolbuffers_wellknowntypes.bufbuild_es/-/protocolbuffers_wellknowntypes.bufbuild_es-1.4.2-20230509212704-657250e6a396.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@buf/protocolbuffers_wellknowntypes.connectrpc_es": {
+      "version": "1.1.3-20230509212704-657250e6a396.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/protocolbuffers_wellknowntypes.connectrpc_es/-/protocolbuffers_wellknowntypes.connectrpc_es-1.1.3-20230509212704-657250e6a396.1.tgz",
+      "dependencies": {
+        "@buf/protocolbuffers_wellknowntypes.bufbuild_es": "1.4.1-20230509212704-657250e6a396.1"
+      },
+      "peerDependencies": {
+        "@connectrpc/connect": "^1.1.3"
+      }
+    },
+    "node_modules/@buf/protocolbuffers_wellknowntypes.connectrpc_es/node_modules/@buf/protocolbuffers_wellknowntypes.bufbuild_es": {
+      "version": "1.4.1-20230509212704-657250e6a396.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/protocolbuffers_wellknowntypes.bufbuild_es/-/protocolbuffers_wellknowntypes.bufbuild_es-1.4.1-20230509212704-657250e6a396.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.1"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.4.2.tgz",
+      "integrity": "sha512-JyEH8Z+OD5Sc2opSg86qMHn1EM1Sa+zj/Tc0ovxdwk56ByVNONJSabuCUbLQp+eKN3rWNfrho0X+3SEqEPXIow=="
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.1.3.tgz",
+      "integrity": "sha512-AXkbsLQe2Nm7VuoN5nqp05GEb9mPa/f5oFzDqTbHME4i8TghTrlY03uefbhuAq4wjsnfDnmuxHZvn6ndlgXmbg==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.3.3"
+      }
+    },
+    "node_modules/@connectrpc/connect-query": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-query/-/connect-query-0.6.0.tgz",
+      "integrity": "sha512-/qqQ1LRfxv+YCfK8DWzzo+sJyxctCwdBmwoTEB6tkNLhKBYn1xD8eGXi1rKCOjfOPWrQXHGCAjsYAJg3WCRl+w==",
+      "peer": true,
+      "dependencies": {
+        "stable-hash": "^0.0.3"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.3.3",
+        "@connectrpc/connect": "^1.1.2",
+        "@tanstack/react-query": "^5.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -209,6 +1182,33 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microlink/react-json-view": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@microlink/react-json-view/-/react-json-view-1.23.0.tgz",
+      "integrity": "sha512-HYJ1nsfO4/qn8afnAMhuk7+5a1vcjEaS8Gm5Vpr1SqdHDY0yLBJGpA+9DvKyxyVKaUkXzKXt3Mif9RcmFSdtYg==",
+      "dependencies": {
+        "flux": "~4.0.1",
+        "react-base16-styling": "~0.6.0",
+        "react-lifecycles-compat": "~3.0.4",
+        "react-textarea-autosize": "~8.3.2"
+      },
+      "peerDependencies": {
+        "react": ">= 15",
+        "react-dom": ">= 15"
+      }
+    },
+    "node_modules/@microlink/react-json-view/node_modules/flux": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
+      "dependencies": {
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -1393,6 +2393,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -1494,6 +2499,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base16": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1993,6 +3003,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2887,6 +3905,33 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fbemitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
+      "dependencies": {
+        "fbjs": "^3.0.0"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -3840,6 +4885,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.curry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
+    },
+    "node_modules/lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4016,6 +5071,25 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
           "optional": true
         }
       }
@@ -4456,6 +5530,14 @@
         "node": ">=16.13"
       }
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4480,6 +5562,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
+      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4511,6 +5598,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-base16-styling": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
+      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
+      "dependencies": {
+        "base16": "^1.0.0",
+        "lodash.curry": "^4.0.1",
+        "lodash.flow": "^3.3.0",
+        "pure-color": "^1.2.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -4528,6 +5626,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.5.5",
@@ -4594,6 +5697,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
+      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -4806,6 +5925,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4857,6 +5981,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.3.tgz",
+      "integrity": "sha512-c63fvNCQ7ip1wBfPv54MflMA5L6OE5J0p6Fg13IpKft4JAFoNal8+s/jtJ8PibrwqXm4onnbeQsADs8k0NQGUA==",
+      "peer": true
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -5147,6 +6277,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -5283,6 +6418,28 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -5357,6 +6514,43 @@
         }
       }
     },
+    "node_modules/use-composed-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.1.tgz",
+      "integrity": "sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
@@ -5406,6 +6600,20 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@buf/cosmos_cosmos-sdk.bufbuild_es": "^1.4.2-20231127085224-6462d33db553.1",
+    "@buf/cosmos_cosmos-sdk.connectrpc_es": "^1.1.3-20231127085224-6462d33db553.1",
+    "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.4.2-20231120132728-bc443669626d.1",
+    "@buf/penumbra-zone_penumbra.connectrpc_es": "^1.1.3-20231120132728-bc443669626d.1",
+    "@buf/penumbra-zone_penumbra.connectrpc_query-es": "^0.6.0-20231120132728-bc443669626d.2",
+    "@bufbuild/protobuf": "^1.4.2",
+    "@connectrpc/connect": "^1.1.3",
+    "@microlink/react-json-view": "^1.23.0",
     "@prisma/client": "^5.4.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",

--- a/src/app/api/ht/route.ts
+++ b/src/app/api/ht/route.ts
@@ -1,4 +1,5 @@
 import db from "@/lib/db";
+import { transactionFromBytes } from "@/lib/protobuf";
 import { BlockHeightValidator } from "@/lib/validators/search";
 import { z } from "zod";
 
@@ -14,7 +15,7 @@ export async function GET(req: Request) {
     // NOTE: This endpoint doesn't return the plain data of a single block. It finds the block by height and, if they exist, attaches any associated events and transaction results.
     //       Duplicate height event attributes are also filtered out.
     console.log(`querying database for block with height ${ht}.`);
-    const block = await db.blocks.findFirstOrThrow({
+    const query = await db.blocks.findFirstOrThrow({
       where: {
         height: ht,
       },
@@ -78,10 +79,23 @@ export async function GET(req: Request) {
       },
     });
 
-    console.log("Successfully queried block:");
-    console.log(block);
+    console.log("Successfully queried block:", query);
 
-    return new Response(JSON.stringify(block));
+    const tx = query.tx_results.at(0);
+    const {tx_results : _, ...block} = query;
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    let tx_hash = "";
+    if (tx !== undefined) {
+      const penumbraTx = transactionFromBytes(tx.tx_result);
+      console.log("Successfully decoded Transaction from blockEvent.tx_results:", penumbraTx);
+
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      tx_hash = tx.tx_hash;
+      return new Response(JSON.stringify([{tx_hash, ...block}, penumbraTx.toJsonString()]));
+    }
+
+    console.log("No Transaction associated with block.");
+    return new Response(JSON.stringify([{tx_hash, ...block}, null]));
   } catch (error) {
     console.log(error);
     if (error instanceof z.ZodError) {

--- a/src/app/block/[ht]/page.tsx
+++ b/src/app/block/[ht]/page.tsx
@@ -19,9 +19,9 @@ const Page : FC<PageProps> = ({ params }) => {
     queryFn: async () => {
       console.log(`Fetching: GET /api/ht?q=${ht}`);
       const { data } = await axios.get(`/api/ht?q=${ht}`);
-      console.log("Fetching result:");
-      console.log(data);
+      console.log("Fetching result:", data);
       const result = BlockResult.safeParse(data);
+      console.log(result);
       if (result.success) {
         return result.data;
       } else {
@@ -51,7 +51,7 @@ const Page : FC<PageProps> = ({ params }) => {
           {blockData ? (
           <div className="flex flex-col justify-center w-full">
             <h1 className="text-3xl mx-auto py-5 font-semibold">Block Summary</h1>
-            <BlockEvent blockEvent={blockData}/>
+            <BlockEvent blockPayload={blockData}/>
           </div>
           ) : (
             <div>

--- a/src/app/tx/[hash]/page.tsx
+++ b/src/app/tx/[hash]/page.tsx
@@ -20,8 +20,7 @@ const Page : FC<PageProps> = ({ params }) => {
     queryFn: async () => {
       console.log(`Fetching: GET /api/tx?q=${hash}`);
       const { data } = await axios.get(`/api/tx?q=${hash}`);
-      console.log("Fetched result:");
-      console.log(data);
+      console.log("Fetched result:", data);
       const result = TransactionResult.safeParse(data);
       if (result.success) {
         return result.data;
@@ -53,7 +52,7 @@ const Page : FC<PageProps> = ({ params }) => {
         {txData ? (
           <div className="flex flex-col justify-center w-full">
             <h1 className="text-3xl mx-auto py-5 font-semibold">Transaction Event Summary</h1>
-            <TransactionEvent txEvent={txData} />
+            <TransactionEvent txPayload={txData} />
           </div>
         ) : (
           <p>No results</p>

--- a/src/components/BlockEvent/index.tsx
+++ b/src/components/BlockEvent/index.tsx
@@ -1,8 +1,9 @@
 import { type BlockResultPayload } from "@/lib/validators/search";
+import ReactJson from "@microlink/react-json-view";
 import { type FC } from "react";
 
 interface BlockEventProps {
-  blockEvent: BlockResultPayload
+  blockPayload: BlockResultPayload
 }
 
 // TODO: Similar to TransactionEvent, it looks increasingly likely that tanstack/table will actually work here so pulling out different DataTable representations will need to happen.
@@ -10,9 +11,8 @@ interface BlockEventProps {
 //       re-write the rendering for BlockEvent. What I'm assuming is that there's meaningful info (and lack-of) to tease out from Blocks
 //       and providing for that will eventually happen here; otherwise, just re-using the same component will make sense instead of mostly
 //       duplicate ui code that shows the exact same information.
-const BlockEvent : FC<BlockEventProps> = ({ blockEvent }) => {
-
-  const tx = blockEvent.tx_results.at(0);
+const BlockEvent : FC<BlockEventProps> = ({ blockPayload }) => {
+  const [blockEvent, penumbraTx] = blockPayload;
 
   return (
     <div className="bg-white rounded-sm">
@@ -27,11 +27,11 @@ const BlockEvent : FC<BlockEventProps> = ({ blockEvent }) => {
         </div>
         <div className="flex flex-col justify-start w-full">
           <p className="w-full">Transaction Event</p>
-          {tx !== undefined ? (
+          {penumbraTx ? (
             <div className="flex w-full flex-wrap gap-y-5 pl-5 pt-5">
               <div className="flex justify-start w-full">
                 <p className="w-1/6">Hash</p>
-                <pre>{tx.tx_hash}</pre>
+                <pre>{blockEvent.tx_hash}</pre>
               </div>
               <div className="flex w-full">
                 <p className="w-1/6 shrink-0">Transaction Result</p>
@@ -39,7 +39,9 @@ const BlockEvent : FC<BlockEventProps> = ({ blockEvent }) => {
                   <summary className="list-none underline font-semibold">
                     click to expand
                   </summary>
-                  <pre className="break-all whitespace-pre-wrap text-xs p-1 bg-slate-100">{tx.tx_result.data}</pre>
+                  <pre className="break-all whitespace-pre-wrap text-xs p-1 bg-slate-100">
+                    <ReactJson src={penumbraTx.toJson() as object} />
+                  </pre>
                 </details>
               </div>
               <p>Event Attributes</p>

--- a/src/components/TransactionEvent/index.tsx
+++ b/src/components/TransactionEvent/index.tsx
@@ -1,11 +1,13 @@
 import { type TransactionResultPayload } from "@/lib/validators/search";
+import ReactJson from "@microlink/react-json-view";
 import { type FC } from "react";
 
 interface TransactionEventProps {
-  txEvent: TransactionResultPayload
+  txPayload: TransactionResultPayload
 }
 
-const TransactionEvent : FC<TransactionEventProps> = ({ txEvent }) => {
+const TransactionEvent : FC<TransactionEventProps> = ({ txPayload }) => {
+  const [txEvent, penumbraTx] = txPayload;
   return (
     <div className="bg-white rounded-sm">
       <div className="flex flex-wrap justify-between p-5 gap-y-10 w-full">
@@ -24,7 +26,9 @@ const TransactionEvent : FC<TransactionEventProps> = ({ txEvent }) => {
               <summary className="list-none underline font-semibold">
                 click to expand
               </summary>
-              <pre className="break-all whitespace-pre-wrap text-xs p-1 bg-slate-100">{txEvent.tx_result.data}</pre>
+              <pre className="break-all whitespace-pre-wrap text-xs p-1 bg-slate-100">
+                <ReactJson src={penumbraTx.toJson() as object}/>
+              </pre>
             </details>
           </div>
         </div>

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -1,0 +1,7 @@
+import { TxResult } from "@buf/cosmos_cosmos-sdk.bufbuild_es/tendermint/abci/types_pb";
+import { Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1alpha1/transaction_pb";
+
+export const transactionFromBytes = (txBytes : Buffer) => {
+  const txResult = TxResult.fromBinary(txBytes);
+  return Transaction.fromBinary(txResult.tx);
+};


### PR DESCRIPTION
This PR adds the protobuf encoding/decoding between the bufbuild definitions for cosmos SDK <-> Penumbra SDK necessary to pull out a JSON value friendly representation of `tx_result` from the indexer. 

This now means that the `tx_result` attribute for each block/transaction view now has a nice JSON rendering of the transaction using @microlink/react-json-view.

Cleaned up some validators and removed duplicated `tx_result` data returned from API endpoints now that the decoded protobuf data is included.