### PR TITLE
`Blocks` table and route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: "standalone",
+    experimental: {
+        serverActions: true,
+    },
 }
 
 module.exports = nextConfig

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -1,6 +1,7 @@
 import db from "@/lib/db";
 
-export async function GET(req: Request) {
+export async function POST(req: Request) {
+  console.log("incoming POST req on /api/blocks/", req);
   try {
     const url = new URL(req.url);
     const pageParam = url.searchParams.get("page")?.trim() ?? "";
@@ -27,7 +28,7 @@ export async function GET(req: Request) {
     ]);
 
     console.log("Successfully queried Blocks count and Blocks.");
-    console.log(count, blocks);
+    console.log([count, blocks]);
 
     const pages = Math.floor((count / 10) + 1);
 

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -1,0 +1,39 @@
+import db from "@/lib/db";
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const pageParam = url.searchParams.get("page")?.trim() ?? "";
+
+    const pageOffset = (parseInt(pageParam, 10)) * 10;
+    
+    const blocksQuery = db.blocks.findMany({
+      select: {
+        height: true,
+        created_at: true,
+      },
+      skip: pageOffset,
+      take: 10,
+      orderBy: {
+        created_at: "desc",
+      },
+    });
+
+
+    console.log("Querying database for recent blocks.");
+    const [count, blocks] = await Promise.all([
+      db.blocks.count(),
+      blocksQuery,
+    ]);
+
+    console.log("Successfully queried Blocks count and Blocks.");
+    console.log(count, blocks);
+
+    const pages = Math.floor((count / 10) + 1);
+
+    return new Response(JSON.stringify([pages, blocks]));
+  } catch (error) {
+    console.error("Error occurred while requesting Blocks", error);
+    return new Response("Could not query blocks.", { status: 404});
+  }
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,9 +1,7 @@
 import db from "@/lib/db";
 
-export const dynamic = "force-dynamic";
-
-export async function GET(req: Request) {
-  console.log("Success: GET /api/events");
+export async function POST(req: Request) {
+  console.log("Success: POST /api/events");
   try {
     const url = new URL(req.url);
     const pageParam = url.searchParams.get("page")?.trim() ?? "";

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,34 +1,11 @@
-"use client";
-
-import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
+import BlocksTable from "@/components/BlocksTable";
 
 const Page = () => {
-  const { data, isFetched, isError } = useQuery({
-    queryFn: async () => {
-      const { data } = await axios.get(`/api/blocks?page=${0}`);
-      return data;
-    },
-    queryKey: ["blocksQuery"],
-    retry: false,
-  });
-
-  if (isError) {
-    return (
-      <div>
-        <h1 className="text-lg font-bold">Error occurred while querying Blocks data...</h1>
-      </div>
-    );
-  }
 
   return (
     <div>
-      <h1 className="text-lg font-bold">Not yet implemented...</h1>
-      { isFetched && (Boolean(data)) ? (
-        <pre>{JSON.stringify(data)}</pre>
-      ) : (
-        <p>no data...</p>
-      )}
+      <h1 className="text-lg font-bold">Recent Blocks</h1>
+      <BlocksTable />
     </div>
   );
 };

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,7 +1,34 @@
-const Page = async () => {
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+const Page = () => {
+  const { data, isFetched, isError } = useQuery({
+    queryFn: async () => {
+      const { data } = await axios.get(`/api/blocks?page=${0}`);
+      return data;
+    },
+    queryKey: ["blocksQuery"],
+    retry: false,
+  });
+
+  if (isError) {
+    return (
+      <div>
+        <h1 className="text-lg font-bold">Error occurred while querying Blocks data...</h1>
+      </div>
+    );
+  }
+
   return (
     <div>
       <h1 className="text-lg font-bold">Not yet implemented...</h1>
+      { isFetched && (Boolean(data)) ? (
+        <pre>{JSON.stringify(data)}</pre>
+      ) : (
+        <p>no data...</p>
+      )}
     </div>
   );
 };

--- a/src/components/BlocksTable/columns.tsx
+++ b/src/components/BlocksTable/columns.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { type ColumnDef } from "@tanstack/react-table";
+import Link from "next/link";
+
+export interface BlocksColumns {
+  height: bigint
+  created_at: string,
+};
+
+// TODO: see comments in TransactionsTable/columns.tsx
+export const columns : Array<ColumnDef<BlocksColumns>> = [
+  {
+    accessorKey: "height",
+    header: () => <div className="font-semibold text-gray-800">Height</div>,
+    cell: ({ row }) => {
+      const ht : bigint = row.getValue("height");
+      return <Link href={`/block/${ht}`} className="underline">{ht.toString()}</Link>;
+    },
+  },
+  {
+    accessorKey: "created_at",
+    header: () => <div className="font-semibold text-gray-800 text-center">Timestamp</div>,
+    cell: ({ row }) => {
+      const timestamp : string = row.getValue("created_at");
+      return <p className="text-xs text-center">{timestamp}</p>;
+    },
+  },
+];

--- a/src/components/BlocksTable/getBlocks.ts
+++ b/src/components/BlocksTable/getBlocks.ts
@@ -1,0 +1,17 @@
+"use server";
+
+import { BlocksTableQuery } from "@/lib/validators/table";
+
+export default async function getBlocks ({ endpoint, pageIndex } : ({ endpoint: string, pageIndex: number })) {
+  console.log(`Fetching: GET ${endpoint}?page=${pageIndex}`);
+  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "POST" });
+  console.log("Fetched result:", res);
+  const json = await res.json();
+  console.log(json);
+  const result = BlocksTableQuery.safeParse(json);
+  if (result.success) {
+    return result.data;
+  } else {
+    throw new Error(result.error.message);
+  }
+}

--- a/src/components/BlocksTable/index.tsx
+++ b/src/components/BlocksTable/index.tsx
@@ -1,0 +1,43 @@
+"use server";
+
+import { columns } from "./columns";
+import { BlocksTableQuery } from "@/lib/validators/table";
+import axios from "axios";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { PaginatedDataTable, type TableQueryKey } from "../ui/paginated-data-table";
+import getBlocks from "./getBlocks";
+
+export interface BlocksTableRow {
+  height: number,
+  createdAt: Date,
+  // TODO: It would be nice to associate all events with a given row. Need to get testnet setup again and pull in example data for building this out.
+  // events: any[],
+};
+
+const BlocksTable = async () => {
+  const queryClient = new QueryClient();
+
+  const defaultQueryOptions = {
+    pageIndex: 1,
+    pageSize: 10,
+  };
+
+  const queryKey: TableQueryKey = ["BlocksTable", defaultQueryOptions];
+  const endpoint = "/api/blocks";
+
+  await queryClient.prefetchQuery({
+    queryFn: async () => await getBlocks({ endpoint, pageIndex: 0}),
+    queryKey,
+    meta: {
+      errorMessage: "Failed to query data while trying to generate blocks table, please try reloading the page.",
+    },
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PaginatedDataTable queryKey={queryKey} columns={columns} fetcher={getBlocks} endpoint={endpoint}/>
+    </HydrationBoundary>
+  );
+};
+
+export default BlocksTable;

--- a/src/components/BlocksTable/index.tsx
+++ b/src/components/BlocksTable/index.tsx
@@ -1,8 +1,6 @@
 "use server";
 
 import { columns } from "./columns";
-import { BlocksTableQuery } from "@/lib/validators/table";
-import axios from "axios";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 import { PaginatedDataTable, type TableQueryKey } from "../ui/paginated-data-table";
 import getBlocks from "./getBlocks";

--- a/src/components/TransactionsTable/getTransactions.ts
+++ b/src/components/TransactionsTable/getTransactions.ts
@@ -1,0 +1,15 @@
+"use server";
+
+import { TableEvents } from "@/lib/validators/table";
+
+export default async function getTransactions({ endpoint, pageIndex } : { endpoint: string, pageIndex: number}) {
+  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "POST" });
+  const json = await res.json();
+  console.log(json);
+  const result = TableEvents.safeParse(json);
+  if (result.success) {
+    return result.data;
+  } else {
+    throw new Error(result.error.message);
+  }
+}

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -1,8 +1,7 @@
 import { columns } from "./columns";
-import { TableEvents } from "@/lib/validators/table";
-import axios from "axios";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
-import { PaginatedDataTable } from "../ui/paginated-data-table";
+import { PaginatedDataTable, type TableQueryKey } from "../ui/paginated-data-table";
+import getTransactions from "./getTransactions";
 
 // TODO: resolve these typings and that with zod and how to navigate between them.
 // NOTE: is it possible to derive a tuple type that encodes the valid combinations of event attributes and their types?
@@ -39,19 +38,23 @@ const TransactionsTable = async () => {
     pageIndex: 1,
     pageSize: 10,
   };
+  const endpoint = "/api/events";
+
+  const queryKey: TableQueryKey = ["TransactionsTable", defaultQueryOptions];
 
   await queryClient.prefetchQuery({
-    queryFn: async () => {
-      const { data } = await axios.get(`/api/events?page=${0}`);
-      console.log(data);
-      const result = TableEvents.safeParse(data);
-      if (result.success) {
-        return result.data;
-      } else {
-        throw new Error(result.error.message);
-      }
-    },
-    queryKey: ["eventTableQuery", defaultQueryOptions],
+    // queryFn: async () => {
+    //   const { data } = await axios.get(`/api/events?page=${0}`);
+    //   console.log(data);
+    //   const result = TableEvents.safeParse(data);
+    //   if (result.success) {
+    //     return result.data;
+    //   } else {
+    //     throw new Error(result.error.message);
+    //   }
+    // },
+    queryFn: async () => await getTransactions({ endpoint, pageIndex: 0}),
+    queryKey,
     meta: {
       errorMessage: "Failed to query data while trying to generate event table, please try reloading the page.",
     },
@@ -59,7 +62,7 @@ const TransactionsTable = async () => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <PaginatedDataTable queryK="eventTableQuery" columns={columns}/>
+      <PaginatedDataTable queryKey={queryKey} columns={columns} endpoint="/api/events" fetcher={getTransactions}/>
     </HydrationBoundary>
   );
 };

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -38,21 +38,11 @@ const TransactionsTable = async () => {
     pageIndex: 1,
     pageSize: 10,
   };
-  const endpoint = "/api/events";
 
+  const endpoint = "/api/events";
   const queryKey: TableQueryKey = ["TransactionsTable", defaultQueryOptions];
 
   await queryClient.prefetchQuery({
-    // queryFn: async () => {
-    //   const { data } = await axios.get(`/api/events?page=${0}`);
-    //   console.log(data);
-    //   const result = TableEvents.safeParse(data);
-    //   if (result.success) {
-    //     return result.data;
-    //   } else {
-    //     throw new Error(result.error.message);
-    //   }
-    // },
     queryFn: async () => await getTransactions({ endpoint, pageIndex: 0}),
     queryKey,
     meta: {

--- a/src/components/ui/paginated-data-table.tsx
+++ b/src/components/ui/paginated-data-table.tsx
@@ -64,6 +64,7 @@ export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
 
   const [pageCount, tableData] : z.infer<Z> = data ?? [0, []];
   console.log("pageCount", pageCount);
+
   const pagination = useMemo(
     () => ({
       pageIndex,

--- a/src/components/ui/paginated-data-table.tsx
+++ b/src/components/ui/paginated-data-table.tsx
@@ -20,50 +20,50 @@ import {
 import { Button } from "@/components/ui/button";
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
-import { TableEvents } from "@/lib/validators/table";
+import { type z } from "zod";
 
-interface PaginatedDataTableProps<TData, TValue> {
+export interface QueryOptions {
+  pageIndex: number,
+  pageSize: number,
+}
+
+export type TableQueryKey = [string, QueryOptions];
+
+interface FetcherParams {
+  endpoint: string,
+  pageIndex: number
+};
+
+type Fetcher<Z extends z.ZodTypeAny> = ({ endpoint, pageIndex} : FetcherParams) => Promise<z.infer<Z>>;
+
+interface PaginatedDataTableProps<TData, TValue, Z extends z.ZodTypeAny> {
   columns: Array<ColumnDef<TData, TValue>>
-  queryK: string,
+  queryKey: TableQueryKey,
+  endpoint: string,
+  fetcher: Fetcher<Z>,
 }
  
-export function PaginatedDataTable<TData, TValue>({
+export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
   columns,
-  queryK,
-}: PaginatedDataTableProps<TData, TValue>) {
+  queryKey,
+  endpoint,
+  fetcher,
+}: PaginatedDataTableProps<TData, TValue, Z>) {
 
-  const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
-  });
+  const options = queryKey[1];
 
-  const queryOptions = {
-    pageIndex,
-    pageSize,
-  };
+  const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({...options});
 
   const { data } = useQuery({
-    queryKey: [queryK, queryOptions],
-    queryFn: async () => {
-      console.log(`Fetching: GET /api/events?page=${pageIndex}`);
-      const { data } = await axios.get(`/api/events?page=${pageIndex}`);
-      console.log("Fetched result:");
-      console.log(data);
-      const result = TableEvents.safeParse(data);
-      if (result.success) {
-        return result.data;
-      } else {
-        throw new Error(result.error.message);
-      }
-    },
+    queryKey,
+    queryFn: async () => await fetcher({ endpoint, pageIndex }),
     meta: {
       errorMessage: "Failed to query paginated data to populate table. Please try again.",
     },
   });
 
-  const [pageCount, eventData] = data ?? [0, []];
-
+  const [pageCount, tableData] : z.infer<Z> = data ?? [0, []];
+  console.log("pageCount", pageCount);
   const pagination = useMemo(
     () => ({
       pageIndex,
@@ -73,7 +73,7 @@ export function PaginatedDataTable<TData, TValue>({
   );
 
   const table = useReactTable({
-    data: eventData as TData[],
+    data: tableData as TData[],
     columns,
     pageCount,
     state: {

--- a/src/lib/validators/table.ts
+++ b/src/lib/validators/table.ts
@@ -1,5 +1,15 @@
 import { z } from "zod";
 
+export const BlocksTableQuery =z.tuple([
+  z.number(),
+  z.array(
+    z.object({
+      height: z.coerce.bigint(),
+      created_at: z.string().datetime(),
+    }),
+  ),
+]);
+
 export const TableEvents = z.tuple([
   z.number(),
   z.array(
@@ -13,4 +23,5 @@ export const TableEvents = z.tuple([
   ),
 ]);
 
+export type BlocksTablePayload = z.infer<typeof BlocksTableQuery>;
 export type TableEventsPayload = z.infer<typeof TableEvents>;


### PR DESCRIPTION
This PR is a part of #6 and #18.

Remaining sub-tasks before I want to merge this:
- [x] add the actual table component.
- [x] add relevant validators
- [x] ensure stylings are consistent between the `/transactions` and `/blocks` endpoints.
- [x] if possible, pull out a common component between these tables.


Next unit of work after this should focus on empty blocks themselves and refactoring `/events`, `/tx`, and `/ht` routes to reflect the general restructuring and changes brought on by #6.