### PR TITLE
feat: docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ A block explorer for [Penumbra](https://penumbra.zone/). Written with NextJS and
 
 ## Getting Started
 
-TODO: a full dockerized setup (built off of Penumbra's own `docker-compose` setup) will be provided for building and running cuiloa. Until then...
+A docker compose file is provided.
+
+```
+docker compose up
+```
+
+Then navigate to http://localhost:3000 to view the app.
+If you want to set up the pieces manually, see below.
 
 ### PostgreSQL
 

--- a/deploy/pd-init-cuiloa
+++ b/deploy/pd-init-cuiloa
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Utility script to configure a new Penumbra node, specifically for Cuiloa.
+# Doing so requires modifying the CometBFT config to use the "psql" indexer.
+# Unfortunately, the tendermint-rs Rust crate used to managed the CometBFT
+# TOML config file via pd doesn't support this config, so we munge it with sed.
+
+
+set -euo pipefail
+
+# Display version info
+pd --version
+
+# Purge any preexisting state
+# rm -rf /pd/testnet_data
+
+if ! test -e /pd/testnet_data/node0/cometbft/config/config.toml ; then
+    >&2 printf "WARN: testnet config not found. Creating fresh node identity."
+    >&2 echo " See docs for details: https://guide.penumbra.zone/main/pd/join-testnet.html"
+    /bin/pd testnet --testnet-dir /pd/testnet_data join
+    sed -i -e 's#^indexer.*#indexer = "psql"\npsql-conn = "postgresql://penumbra:penumbra@postgres:5432/penumbra?sslmode=disable"#' /pd/testnet_data/node0/cometbft/config/config.toml
+    grep psql /pd/testnet_data/node0/cometbft/config/config.toml
+else
+    >&2 echo 'Node config already found, using it'
+fi
+
+chown 100 -R /pd/testnet_data/node0/cometbft
+chown 1000 -R /pd/testnet_data/node0/pd
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+---
+# docker-compose file for running Cuiloa, a block explorer for Penumbra
+
+# N.B. the version tag for Penumbra container images should be updated manually,
+# to track the latest version available in the public releases:
+# https://github.com/penumbra-zone/penumbra/releases
+version: "3.7"
+services:
+  # Initialize node config, via `pd testnet join`. This init container handles
+  # munging the CometBFT config to enable event indexing via psql.
+  pd-init:
+    image: ghcr.io/penumbra-zone/penumbra:v0.64.1
+    command: /usr/local/bin/pd-init-cuiloa
+    restart: "no"
+    volumes:
+      - cuiloa-pd:/pd
+      - ./deploy/pd-init-cuiloa:/usr/local/bin/pd-init-cuiloa:ro
+    # run initcontainer as root so we can chown dirs for app containers.
+    user: "0"
+
+  # The Penumbra daemon
+  pd:
+    image: ghcr.io/penumbra-zone/penumbra:v0.64.1
+    # consider verbose debugging logs:
+    # environment:
+      # RUST_LOG: h2=off,debug
+    command: >-
+      /bin/pd start --home /pd/testnet_data/node0/pd
+      --grpc-bind 0.0.0.0:8080 --abci-bind 0.0.0.0:26658
+    restart: on-failure
+    volumes:
+      - cuiloa-pd:/pd
+    # OK, I caved: running the pd container as root to avoid permissions problems.
+    # Ideally we'd run as 1000, same as in the container image, but alas.
+    # user: "1000"
+    user: "0"
+    depends_on:
+      pd-init:
+        condition: service_completed_successfully
+    ports:
+      - "26658:26658"
+      - "8080:8080"
+
+  # The CometBFT node
+  cometbft:
+    image: "docker.io/cometbft/cometbft:v0.37.2"
+    ports:
+      - "26656:26656"
+      - "26657:26657"
+    volumes:
+      - cuiloa-pd:/cometbft
+    user: "100"
+    environment:
+      CMTHOME: /cometbft/testnet_data/node0/cometbft
+    command: start --proxy_app=tcp://pd:26658
+    depends_on:
+      - postgres
+
+  # The Postgres database, for storing CometBFT indexing info
+  postgres:
+    image: "docker.io/library/postgres:latest"
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./deploy/postgres-cometbft-schema.sql:/docker-entrypoint-initdb.d/postgres-cometbft-schema.sql:ro
+    environment:
+      POSTGRES_PASSWORD: penumbra
+      POSTGRES_USER: penumbra
+      POSTGRES_DB: penumbra
+    depends_on:
+      - pd
+
+  # The Cuiloa application, providing a web-based block explorer for Penumbra.
+  cuiloa:
+    build:
+      context: ./
+      dockerfile: Containerfile
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: 'postgresql://penumbra:penumbra@postgres:5432/penumbra?sslmode=disable'
+    depends_on:
+      - postgres
+
+volumes:
+  cuiloa-pd: {}

--- a/justfile
+++ b/justfile
@@ -20,3 +20,10 @@ update-cometbft-schema:
 
 container:
   podman build -t ghcr.io/penumbra-zone/cuiloa .
+
+compose:
+  docker compose up
+
+podman-compose:
+  podman compose down || true
+  podman-compose up --build --abort-on-container-exit --force-recreate --renew-anon-volumes --remove-orphans --pull-always


### PR DESCRIPTION
Based on the upstream Penumbra setup, but here we add a postgres container and of course the cuiloa container itself. Significantly, we munge the pd-generated cometbft config to enable indexing to postgres, which is a requirement for cuiloa.

This PR resurrects https://github.com/penumbra-zone/cuiloa/pull/1 and adapts that work for the latest version of the cuiloa setup.

### Testing
So far, I've only used `just podman-compose` myself. @ejmg I'd appreciate if you tried out the `just compose` target and report back on how it works for you. 