### PR TITLE
basic search endpoint 

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,77 @@
+import db from "@/lib/db";
+import { QueryKind, SearchValidator } from "@/lib/validators/search";
+
+export async function POST(req: Request) {
+  console.log("POST req on /api/search", req);
+  try {
+    const url = new URL(req.url);
+    const queryParam = url.searchParams.get("q")?.trim() ?? "";
+    console.log(queryParam);
+
+    const res = SearchValidator.safeParse(queryParam);
+    if (!res.success) {
+      return new Response("Invalid query", { status: 404 });
+    }
+
+    const searchQuery = res.data;
+    // TODO: pagination will be more relevant when there are different types of values to search across for a given query...
+    //       i.e. for a given block height, find any associated ABCI stuff
+    // const pageParam = url.searchParams.get("page")?.trim() ?? "";
+    // const pageOffset = (parseInt(pageParam, 10)) * 10;
+
+    if (searchQuery.kind === QueryKind.BlockHeight) {
+      const blocksQuery = db.blocks.findMany({
+        select: {
+          height: true,
+          created_at: true,
+        },
+        where: {
+          // value will be bigint when kind is BlockHeight
+          height: searchQuery.value as bigint,
+        },
+      });
+      return new Response(JSON.stringify([blocksQuery]));
+    } else if (searchQuery.kind === QueryKind.TxHash) {
+      const txQuery = await db.tx_results.findFirstOrThrow({
+        select: {
+          tx_hash: true,
+          tx_result: true,
+          created_at: true,
+          events: {
+            select: {
+              type: true,
+              attributes: {
+                select: {
+                  key: true,
+                  value: true,
+                },
+              },
+            },
+            where: {
+              NOT: {
+                type: "tx",
+              },
+            },
+          },
+          blocks: {
+            select: {
+              height: true,
+              chain_id: true,
+            },
+          },
+        },
+        where: {
+          // value will be string when kind is TxHash
+          tx_hash: searchQuery.value as string,
+        },
+      });
+      return new Response(JSON.stringify([txQuery]));
+    } else {
+      // This should be impossible.
+      return new Response("Error processing query.", { status: 500 });
+    }
+  } catch (error) {
+    console.error("Error occurred while searching query.", error);
+    return new Response("Could not search query.", { status: 404});
+  }
+}

--- a/src/lib/validators/search.ts
+++ b/src/lib/validators/search.ts
@@ -23,6 +23,30 @@ export const BlockHeightValidator = z.bigint().nonnegative({ message: "Block hei
 export type HashResultQuery = z.infer<typeof HashResultValidator>;
 export type BlockHeightQuery = z.infer<typeof BlockHeightValidator>;
 
+// TODO: There might be a more "correct" way to rely on Zod's typings to enforce the types that will eventually
+//       represent all query types but this is an OK approximation for now.
+//       i.e. Define an enum of QueryKinds and then an union of tuples with the tagged QueryKind and the associated validator for that kind, QueryValidator.
+//            This will ensure that only records with a kind of "TX_HASH" will have a value of HashResultQuery (ie a correctly formated hash string), and
+//            records with "BLOCK_HEIGHT" will only have a value of BlockHeightQuery (bigint), etc.
+
+export enum QueryKind {
+  TxHash = "TX_HASH",
+  BlockHeight = "BLOCK_HEIGHT",
+}
+
+const HashResultSearchValidator = HashResultValidator
+  .transform((val) => ({ kind: "TX_HASH", value: val }));
+
+export const BlockHeightSearchValidator = BlockHeightValidator
+  .transform((val) => ({ kind: "BLOCK_HEIGHT", value: val }));
+
+export const SearchValidator = z.union([
+  HashResultSearchValidator,
+  BlockHeightSearchValidator,
+]);
+
+export type SearchValidatorResult = z.infer<typeof SearchValidator>;
+
 // zod schema equivalent to the /parsed/ JSON data returned by prisma in GET /api/transaction?q=<hash>
 export const TransactionResult = z.tuple([
   z.object({


### PR DESCRIPTION
part of #20, #10, and #6.

Basic API endpoint for search + validators for checking across query kinds. The validators could be more robust IMO but they're good enough as far as typescript types go.