### PR TITLE
Basic search support for IBC related queries

### DIFF
--- a/src/app/api/ibc/channel/route.ts
+++ b/src/app/api/ibc/channel/route.ts
@@ -133,7 +133,7 @@ export async function GET(req: NextRequest) {
 
     console.log("Successfully queried for latest client height.", clientHeight);
 
-    // This will return the block id for the latest client_update event type for a given client_id.
+    // This will return the latest transactions that are associated with the channel.
     const transactions = await db.events.findMany({
       select: {
         tx_results: {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -23,7 +23,6 @@ export async function POST(req: Request) {
       const blocksQuery = await db.blocks.findFirst({
         select: {
           height: true,
-          created_at: true,
         },
         where: {
           // value will be bigint when kind is BlockHeight
@@ -33,15 +32,13 @@ export async function POST(req: Request) {
 
       return new Response(JSON.stringify({
         kind: searchQuery.kind,
-        created_at: blocksQuery?.created_at,
-        value: blocksQuery?.height,
+        identifier: blocksQuery?.height,
       }));
 
     } else if (searchQuery.kind === QueryKind.TxHash) {
       const txQuery = await db.tx_results.findFirst({
         select: {
           tx_hash: true,
-          created_at: true,
         },
         where: {
           // value will be string when kind is TxHash
@@ -50,10 +47,10 @@ export async function POST(req: Request) {
       });
       return new Response(JSON.stringify({
         kind: searchQuery.kind,
-        created_at: txQuery?.created_at,
-        value: txQuery?.tx_hash,
+        identifier: txQuery?.tx_hash,
       }));
     } else if (searchQuery.kind === QueryKind.IbcClient) {
+      console.log("SEARCHING IBC CLIENT...");
       const clientQuery = await db.events.findMany({
         select: {
           type: true,
@@ -87,11 +84,11 @@ export async function POST(req: Request) {
         take: 10,
       });
       console.log("Successfully queried for IBC Client Search Results.", clientQuery);
-      const clientData = clientQuery.map(({ type, tx_results: txResults }) => ({type, hash: txResults?.tx_hash }));
+      const clientData = clientQuery.map(({ type, tx_results: txResults }) => ({type, identifier: txResults?.tx_hash }));
       return new Response(JSON.stringify({
         kind: searchQuery.kind,
-        created_at: undefined,
-        value: JSON.stringify(clientData),
+        identifier: searchQuery.value,
+        related: clientData,
       }));
     } else {
       // This should be impossible.

--- a/src/app/search/[query]/page.tsx
+++ b/src/app/search/[query]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import SearchResultsTable from "@/components/SearchResultsTable";
-import { SearchResultValidator } from "@/lib/validators/search";
+// import { SearchResultValidator } from "@/lib/validators/search";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { type FC } from "react";
@@ -19,13 +19,14 @@ const Page : FC<PageProps> = ({ params }) => {
       console.log(`Fetching: GET /api/search?q=${query}`);
       const { data } = await axios.post(`/api/search?q=${query}`);
       console.log("Fetched result:", data);
-      const result = SearchResultValidator.safeParse(data);
-      if (result.success) {
-        console.log(result.data);
-        return result.data;
-      } else {
-        throw new Error(result.error.message);
-      }
+      return data;
+      // const result = SearchResultValidator.safeParse(data);
+      // if (result.success) {
+      //   console.log(result.data);
+      //   return result.data;
+      // } else {
+      //   throw new Error(result.error.message);
+      // }
     },
     queryKey: ["searchResult", query],
     retry: false,
@@ -47,7 +48,8 @@ const Page : FC<PageProps> = ({ params }) => {
       {isFetched ? (
         <div>
           <h1 className="text-3xl mx-auto py-5 font-semibold">Search results</h1>
-        {searchResultData ? (
+        {// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        searchResultData ? (
           <div className="flex flex-col justify-center w-full">
             <SearchResultsTable data={[searchResultData]}/>
           </div>

--- a/src/components/SearchResultsTable/columns.tsx
+++ b/src/components/SearchResultsTable/columns.tsx
@@ -1,14 +1,12 @@
 "use client";
 
-import { QueryKind } from "@/lib/validators/search";
+// import { QueryKind } from "@/lib/validators/search";
 import { type ColumnDef } from "@tanstack/react-table";
-import Link from "next/link";
+// import Link from "next/link";
+import { type RelatedQuery, type SearchResult } from ".";
 
-export interface SearchResultsColumns {
-  kind: string,
-  created_at?: string,
-  value?: string | bigint
-};
+
+type SearchResultsColumns = SearchResult;
 
 export const columns : Array<ColumnDef<SearchResultsColumns>> = [
   {
@@ -20,26 +18,40 @@ export const columns : Array<ColumnDef<SearchResultsColumns>> = [
     },
   },
   {
-    accessorKey: "created_at",
-    header: () => <div className="font-semibold text-gray-800 text-center">Timestamp</div>,
+    accessorKey: "identifier",
+    header: () => <div className="font-semibold text-gray-800 text-center">ID</div>,
     cell: ({ row }) => {
-      const createdAt : string = row.getValue("created_at");
-      return <p className="text-xs text-center">{createdAt}</p>;
+      const identifier : string = row.getValue("identifier");
+      return <p className="text-xs text-center">{identifier}</p>;
     },
   },
   {
-    accessorKey: "value",
-    header: () => <div className="font-semibold text-gray-800 text-center">value</div>,
+    id: "related",
+    accessorKey: "related",
+    header: () => <div className="font-semibold text-gray-800 text-center">Related Queries</div>,
     cell: ({ row }) => {
       console.log(row);
-      const kind : string = row.getValue("kind");
-      if (kind === QueryKind.BlockHeight) {
-        const height: bigint = row.getValue("value");
-        return <Link href={`/block/${height}`} className="underline">{height.toString()}</Link>;
-      } else if (kind === QueryKind.TxHash) {
-        const txHash: string = row.getValue("value");
-        return <Link href={`/transaction/${txHash}`} className="underline">{txHash}</Link>;
+      // const kind : string = row.getValue("kind");
+      const related : RelatedQuery[] | undefined = row.getValue("related");
+      // TODO: Do some kind of convenient formatting that better signals what is being shown to the user
+      // if (kind === QueryKind.BlockHeight) {
+      //   const height: bigint = row.getValue("value");
+      //   return <Link href={`/block/${height}`} className="underline">{height.toString()}</Link>;
+      // } else if (kind === QueryKind.TxHash) {
+      //   const txHash: string = row.getValue("value");
+      //   return <Link href={`/transaction/${txHash}`} className="underline">{txHash}</Link>;
+      // }
+      if (related !== undefined) {
+        console.log(related);
+        console.log(related.map);
+        return (
+        <ul>
+          {/* {related.map(({ type, indentifier }, i) => <li key={i}>{type} : {indentifier}</li>)} */}
+          {related.map(({ type, identifier }, i) => (<div key={i}>{type}: {identifier}</div>))}
+        </ul>
+        );
       }
+      return <div>None</div>;
     },
   },
 ];

--- a/src/components/SearchResultsTable/index.tsx
+++ b/src/components/SearchResultsTable/index.tsx
@@ -1,17 +1,29 @@
 import { columns } from "./columns";
 import { DataTable } from "../ui/data-table";
-// import { type QueryKind } from "@/lib/validators/search";
 import { type FC } from "react";
 
-interface Props {
+interface RelatedIbcTransaction {
+  type: string,
+  hash: string,
+}
+
+interface IbcSearchResult {
+  kind: string,
+  identifier: string,
+  related?: RelatedIbcTransaction[],
+}
+// TODO?
+// interface TransactionSearchResult {}
+// interface BlockSearchResult {}
+interface SearchResultsTableProps {
   data: Array<{
     kind: string,
     created_at?: string,
     value?: string | bigint
-  }>,
+  }> | IbcSearchResult[],
 }
 
-const SearchResultsTable : FC<Props> = ({ data }) => {
+const SearchResultsTable : FC<SearchResultsTableProps> = ({ data }) => {
   return (
     <div>
       <DataTable columns={columns} data={data}/>

--- a/src/components/SearchResultsTable/index.tsx
+++ b/src/components/SearchResultsTable/index.tsx
@@ -2,31 +2,30 @@ import { columns } from "./columns";
 import { DataTable } from "../ui/data-table";
 import { type FC } from "react";
 
-interface RelatedIbcTransaction {
+
+export interface RelatedQuery {
   type: string,
-  hash: string,
+  identifier: string,
 }
 
-interface IbcSearchResult {
+export interface SearchResult {
   kind: string,
   identifier: string,
-  related?: RelatedIbcTransaction[],
+  related?: RelatedQuery[],
 }
 // TODO?
 // interface TransactionSearchResult {}
 // interface BlockSearchResult {}
 interface SearchResultsTableProps {
-  data: Array<{
-    kind: string,
-    created_at?: string,
-    value?: string | bigint
-  }> | IbcSearchResult[],
+  data: SearchResult[]
 }
 
 const SearchResultsTable : FC<SearchResultsTableProps> = ({ data }) => {
+  const relatedVisible = !!data[0].related;
+  console.log("relatedVisible", relatedVisible);
   return (
     <div>
-      <DataTable columns={columns} data={data}/>
+      <DataTable columns={columns} data={data} columnVisibility={{ "related": relatedVisible }}/>
     </div>
   );
 };

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -5,6 +5,7 @@ import {
   flexRender,
   getCoreRowModel,
   useReactTable,
+  type VisibilityState,
 } from "@tanstack/react-table";
  
 import {
@@ -17,20 +18,29 @@ import {
 } from "@/components/ui/Table";
 
 interface DataTableProps<TData, TValue> {
-  columns: Array<ColumnDef<TData, TValue>>
+  columns: Array<ColumnDef<TData, TValue>>,
+  columnVisibility?: VisibilityState,
   data: TData[],
 }
  
 export function DataTable<TData, TValue>({
   columns,
+  columnVisibility,
   data,
 }: DataTableProps<TData, TValue>) {
+
+  console.log("columnVisibility", columnVisibility);
 
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    initialState: {
+      columnVisibility,
+    },
   });
+
+  console.log("table state", table.getState());
 
   return (
     <div>

--- a/src/lib/validators/search.ts
+++ b/src/lib/validators/search.ts
@@ -22,15 +22,15 @@ export const BlockHeightValidator = z.bigint().nonnegative({ message: "Block hei
 
 // Validator for IBC Complient *Client* Identifiers.[0]
 // [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
-export const IbcClientValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{9,64})$/);
+export const IbcClientValidator = z.string().regex(/^([A-Za-z0-9.[\]<>_+\-#]{9,64})$/);
 
 // Validator for IBC Complient *Channel* Identifiers.[0]
 // [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
-export const IbcChannelValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{8,64})$/);
+export const IbcChannelValidator = z.string().regex(/^([A-Za-z0-9.[\]<>_+\-#]{8,64})$/);
 
 // Validator for IBC Complient *Connection* Identifiers.[0]
 // [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
-export const IbcConnectionValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{10,64})$/);
+export const IbcConnectionValidator = z.string().regex(/^([A-Za-z0-9.[\]<>_+\-#]{10,64})$/);
 
 export type HashResultQuery = z.infer<typeof HashResultValidator>;
 export type BlockHeightQuery = z.infer<typeof BlockHeightValidator>;
@@ -52,6 +52,9 @@ export enum QueryKind {
   TxHash = "TX_HASH",
 }
 
+// NOTE: would it be worth converting these branded values into using the ts enum value intead of the string literals?
+//       more a question with how zod plays with those values and how it differentiates them. might also be why my code ended up this way
+//       without realizing it.
 const HashResultSearchValidator = HashResultValidator
   .transform((val) => ({ kind: "TX_HASH", value: val }));
 
@@ -67,6 +70,7 @@ export const IbcChannelSearchValidator = IbcChannelValidator
 export const IbcConnectionSearchValidator = IbcConnectionValidator
   .transform((val) => ({ kind: "IBC_CONNECTION", value: val }));
 
+// Validator used for checking whether a user's search query input is recognized and supported.
 export const SearchValidator = z.union([
   HashResultSearchValidator,
   BlockHeightSearchValidator,

--- a/src/lib/validators/search.ts
+++ b/src/lib/validators/search.ts
@@ -20,8 +20,23 @@ const toNonNegInt = z.number().or(z.string()).pipe(z.coerce.number().int().nonne
 // `blocks` table defined in cometbft's psql indexer schema. The final .pipe() doesn't require a nonnegative check because of toNonNegInt.
 export const BlockHeightValidator = z.bigint().nonnegative({ message: "Block height must be a non-negative integer."}).or(toNonNegInt).pipe(z.coerce.bigint());
 
+// Validator for IBC Complient *Client* Identifiers.[0]
+// [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
+export const IbcClientValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{9,64})$/);
+
+// Validator for IBC Complient *Channel* Identifiers.[0]
+// [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
+export const IbcChannelValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{8,64})$/);
+
+// Validator for IBC Complient *Connection* Identifiers.[0]
+// [0]: https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
+export const IbcConnectionValidator = z.string().regex(/^([A-Za-z0-9\.\[\]<>_+-#]{10,64})$/);
+
 export type HashResultQuery = z.infer<typeof HashResultValidator>;
 export type BlockHeightQuery = z.infer<typeof BlockHeightValidator>;
+export type IbcClientValidatorT = z.infer<typeof IbcClientValidator>;
+export type IbcChannelValidatorT = z.infer<typeof IbcChannelValidator>;
+export type IbcConnectionValidatorT = z.infer<typeof IbcConnectionValidator>;
 
 // TODO: There might be a more "correct" way to rely on Zod's typings to enforce the types that will eventually
 //       represent all query types but this is an OK approximation for now.
@@ -30,8 +45,11 @@ export type BlockHeightQuery = z.infer<typeof BlockHeightValidator>;
 //            records with "BLOCK_HEIGHT" will only have a value of BlockHeightQuery (bigint), etc.
 
 export enum QueryKind {
-  TxHash = "TX_HASH",
   BlockHeight = "BLOCK_HEIGHT",
+  IbcClient = "IBC_CLIENT",
+  IbcChannel = "IBC_CHANNEL",
+  IBCConnection = "IBC_CONNECTION",
+  TxHash = "TX_HASH",
 }
 
 const HashResultSearchValidator = HashResultValidator
@@ -40,13 +58,29 @@ const HashResultSearchValidator = HashResultValidator
 export const BlockHeightSearchValidator = BlockHeightValidator
   .transform((val) => ({ kind: "BLOCK_HEIGHT", value: val }));
 
+export const IbcClientSearchValidator = IbcClientValidator
+  .transform((val) => ({ kind: "IBC_CLIENT", value: val }));
+
+export const IbcChannelSearchValidator = IbcChannelValidator
+  .transform((val) => ({ kind: "IBC_CHANNEL", value: val }));
+
+export const IbcConnectionSearchValidator = IbcConnectionValidator
+  .transform((val) => ({ kind: "IBC_CONNECTION", value: val }));
+
 export const SearchValidator = z.union([
   HashResultSearchValidator,
   BlockHeightSearchValidator,
+  IbcClientSearchValidator,
+  IbcChannelSearchValidator,
+  IbcConnectionSearchValidator,
 ]);
 
 export type SearchValidatorT = z.infer<typeof SearchValidator>;
 
+// Validators used for checking the result of searched queries represented as a discriminate union where the QueryKind serves as the discriminate.
+// Query Kinds supported ought to be defined in both `SearchValidator` and `QueryKind`.
+// NOTE: Completely forgot why I felt the need to chain optionals from within the discriminated record. Another thing in need of documentation
+//       if not refactored in the next pass of cleaning up the codebase.
 export const SearchResultValidator = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("TX_HASH"),
@@ -56,6 +90,21 @@ export const SearchResultValidator = z.discriminatedUnion("kind", [
   z.object({
     kind: z.literal("BLOCK_HEIGHT"),
     value: BlockHeightValidator.optional(),
+    created_at: z.string().datetime().optional(),
+  }),
+  z.object({
+    kind: z.literal("IBC_CLIENT"),
+    value: IbcClientValidator.optional(),
+    created_at: z.string().datetime().optional(),
+  }),
+  z.object({
+    kind: z.literal("IBC_CHANNEL"),
+    value: IbcChannelValidator.optional(),
+    created_at: z.string().datetime().optional(),
+  }),
+  z.object({
+    kind: z.literal("IBC_CONNECTION"),
+    value: IbcConnectionValidator.optional(),
     created_at: z.string().datetime().optional(),
   }),
 ]);


### PR DESCRIPTION
Part of #10, #61 

This WIP PR is the first step to adding IBC support to the search functionality of Cuiloa. As of now, can ping the API endpoint with an IBC Client identifier and get back results containing related transactions and their types.

The goal of this PR is to have basic support for just IBC Clients but it will also be handling most of the core refactoring relevant to also supporting Channels (#62) and Connections (#63).

Stylings and the API for the search results table component are still being hammered out along with the best way to structure some of these queries.