### PR TITLE
Link to block height and show all ABCI events on Transaction

### DIFF
--- a/src/app/api/transaction/route.ts
+++ b/src/app/api/transaction/route.ts
@@ -28,11 +28,6 @@ export async function GET(req: Request) {
               },
             },
           },
-          where: {
-            NOT: {
-              type: "tx",
-            },
-          },
         },
         blocks: {
           select: {

--- a/src/app/transaction/[hash]/page.tsx
+++ b/src/app/transaction/[hash]/page.tsx
@@ -50,9 +50,9 @@ const Page : FC<PageProps> = ({ params }) => {
       {isFetched ? (
         <div>
         {txData ? (
-          <div className="flex flex-col justify-center w-full">
-            <h1 className="text-3xl mx-auto py-5 font-semibold">Transaction Event Summary</h1>
-            <Transaction txPayload={txData} />
+          <div className="flex flex-col items-center gap-5">
+            <h1 className="sm:text-2xl font-bold">Transaction Event Summary</h1>
+            <Transaction txData={txData} />
           </div>
         ) : (
           <p>No results</p>

--- a/src/components/Transaction/index.tsx
+++ b/src/components/Transaction/index.tsx
@@ -1,13 +1,14 @@
 import { type TransactionResultPayload } from "@/lib/validators/search";
 import ReactJson from "@microlink/react-json-view";
+import Link from "next/link";
 import { type FC } from "react";
 
 interface TransactionProps {
-  txPayload: TransactionResultPayload
+  txData: TransactionResultPayload
 }
 
-const Transaction : FC<TransactionProps> = ({ txPayload }) => {
-  const [txEvent, penumbraTx] = txPayload;
+const Transaction : FC<TransactionProps> = ({ txData }) => {
+  const [txEvent, penumbraTx] = txData;
   return (
     <div className="bg-white rounded-sm">
       <div className="flex flex-wrap justify-between p-5 gap-y-10 w-full">
@@ -17,7 +18,7 @@ const Transaction : FC<TransactionProps> = ({ txPayload }) => {
         </div>
         <div className="flex justify-start w-full">
           <p className="w-1/6">Block Height</p>
-          <pre>{txEvent.blocks.height.toString()}</pre>
+          <Link href={`/block/${txEvent.blocks.height}`}><pre className="underline">{txEvent.blocks.height.toString()}</pre></Link>
         </div>
         <div className="flex justify-start w-full">
           <p className="w-1/6">Timestamp</p>


### PR DESCRIPTION
Part of #6, #21, #52.

Added links to block height, stopped filtering ABCI events at API endpoint, and mild restyling to match new responsive styles (to be finished after tables are added).