### PR TITLE
ABCI Events Table for Block and Transaction pages

### DIFF
--- a/src/components/ABCIEventsTable/columns.tsx
+++ b/src/components/ABCIEventsTable/columns.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { type ColumnDef } from "@tanstack/react-table";
+
+export type ABCIEventsColumns = Record<number, {
+  type: string,
+  key: string,
+  value: string | null,
+}>;
+
+export const columns : Array<ColumnDef<ABCIEventsColumns>> = [
+  {
+    id: "type",
+    // accessorFn: (row) => row[0].value,
+    accessorKey: "type",
+    header: () => <div className="font-semibold text-gray-800 text-center sm:text-lg text-sm">Type</div>,
+    cell: ({ getValue }) => {
+      const abciType = getValue() as string;
+      return <pre className="text-center">{abciType}</pre>;
+    },
+  },
+  {
+    id: "key",
+    // accessorFn: (row) => row[0].value,
+    accessorKey: "key",
+    header: () => <div className="font-semibold text-gray-800 text-center sm:text-lg text-sm">Key</div>,
+    cell: ({ getValue }) => {
+      const abciKey = getValue() as string;
+      return <pre className="text-center">{abciKey}</pre>;
+    },
+  },
+  {
+    id: "value",
+    accessorKey: "value",
+    header: () => <div className="font-semibold text-gray-800 text-center sm:text-lg text-sm">Value</div>,
+    cell: ({ getValue }) => {
+      const abciValue : string = getValue() as string | null ?? "None";
+      return <pre className="text-center">{abciValue}</pre>;
+    },
+  },
+];

--- a/src/components/ABCIEventsTable/index.tsx
+++ b/src/components/ABCIEventsTable/index.tsx
@@ -1,0 +1,20 @@
+import { columns } from "./columns";
+import { DataTable } from "../ui/data-table";
+import { type FC } from "react";
+
+interface Props {
+  className?: string,
+  data: Array<{
+    type: string,
+    key: string,
+    value: string | null,
+  }>,
+}
+
+const ABCIEventsTable : FC<Props> = ({ className, data }) => {
+  return (
+    <DataTable className={className} columns={columns} data={data}/>
+  );
+};
+
+export default ABCIEventsTable;


### PR DESCRIPTION
part of #6, #52, #35.

This PR adds an `ABCIEventsTable` component that will be used by both `/block/[HEIGHT]` and `transaction/[HASH]` pages.