### PR TITLE
Restyled ABCIEventsTable into two-column KV and updated Block, Transaction Pages to match restyling.

### DIFF
--- a/src/app/api/block/route.ts
+++ b/src/app/api/block/route.ts
@@ -49,13 +49,8 @@ export async function GET(req: Request) {
     });
 
     console.log("Successfully queried block data: ", query, query.events);
-    // NOTE: doing this for the same reason outlined in /api/transaction/route.ts#L50
-    const { events: _events, ...block} = query;
-    const events = _events.map(({ type, attributes }) => {
-      return attributes.map(({ key, value }) => ({ type, key, value }));
-    }).flat();
 
-    return new Response(JSON.stringify({...block, events}));
+    return new Response(JSON.stringify(query));
   } catch (error) {
     console.log(error);
     if (error instanceof z.ZodError) {

--- a/src/app/api/transaction/route.ts
+++ b/src/app/api/transaction/route.ts
@@ -45,24 +45,9 @@ export async function GET(req: Request) {
     console.log("Successfully decoded Transaction from tx_result:", penumbraTx);
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { tx_result, events: _events, ...tx} = query;
+    const { tx_result, ...tx} = query;
 
-    // NOTE: I Cannot Wait To Remove PrismaJS.
-    // This flattens our ABCI data such that:
-    // { type: string, 
-    //   attributes: Array<{
-    //     key: string,
-    //     value: string | null }>}
-    // } becomes:
-    // { type: string,
-    //   key: string,
-    //   value: string | null }
-    // Whether or not it would be better to nest this day for rendering in the table is TBD.
-    const events = _events.map(({ type, attributes }) => {
-      return attributes.map(({ key, value }) => ({ type, key, value }));
-    }).flat();
-
-    return new Response(JSON.stringify([{...tx, events}, penumbraTx.toJsonString()]));
+    return new Response(JSON.stringify([tx, penumbraTx.toJsonString()]));
   } catch (error) {
     console.log(error);
     if (error instanceof z.ZodError) {

--- a/src/components/ABCIEventsTable/columns.tsx
+++ b/src/components/ABCIEventsTable/columns.tsx
@@ -10,27 +10,19 @@ export type ABCIEventsColumns = Record<number, {
 
 export const columns : Array<ColumnDef<ABCIEventsColumns>> = [
   {
-    accessorKey: "type",
-    header: () => <div className="font-semibold text-gray-800 text-center sm:text-base text-sm">Type</div>,
-    cell: ({ getValue }) => {
-      const abciType = getValue() as string;
-      return <pre className="text-center sm:whitespace-normal whitespace-pre-wrap sm:break-normal break-all sm:w-auto sm:text-sm text-xs">{abciType}</pre>;
-    },
-  },
-  {
     accessorKey: "key",
-    header: () => <div className="font-semibold text-gray-800 text-center sm:text-base text-sm">Key</div>,
+    header: () => <div className="font-semibold text-gray-800 text-center text-sm">Key</div>,
     cell: ({ getValue }) => {
       const abciKey = getValue() as string;
-      return <pre className="sm:whitespace-normal whitespace-pre-wrap sm:break-normal break-all text-center sm:text-sm text-xs">{abciKey}</pre>;
+      return <pre className="text-center sm:text-sm text-xs">{abciKey}</pre>;
     },
   },
   {
     accessorKey: "value",
-    header: () => <div className="font-semibold text-gray-800 text-center sm:text-base text-sm">Value</div>,
+    header: () => <div className="font-semibold text-gray-800 text-center text-sm">Value</div>,
     cell: ({ getValue }) => {
       const abciValue : string = getValue() as string | null ?? "None";
-      return <pre className="text-center break-all whitespace-pre-wrap sm:w-auto w-[120px] sm:text-sm text-xs">{abciValue}</pre>;
+      return <pre className="text-center  break-all whitespace-pre-wrap sm:w-auto sm:px-0 px-2 sm:text-sm text-xs">{abciValue}</pre>;
     },
   },
 ];

--- a/src/components/ABCIEventsTable/index.tsx
+++ b/src/components/ABCIEventsTable/index.tsx
@@ -5,7 +5,6 @@ import { type FC } from "react";
 interface Props {
   className?: string,
   data: Array<{
-    type: string,
     key: string,
     value: string | null,
   }>,

--- a/src/components/Block/index.tsx
+++ b/src/components/Block/index.tsx
@@ -30,9 +30,14 @@ const Block : FC<BlockEventProps> = ({ blockData }) => {
               <Link href={`/transaction/${tx_hash}`} key={i}><pre className="underline sm:max-w-full max-w-[200px] overflow-hidden overflow-ellipsis sm:text-base">{tx_hash}</pre></Link>
           )) : <p className="sm:w-0 w-full overflow-hidden text-ellipsis">None</p>}
         </div>
-        <div className="flex flex-col items-center gap-5 w-full">
+        <div className="flex justify-start flex-wrap w-full">
           <p className="font-bold text-base">Block Event Attributes</p>
-          <ABCIEventsTable className="w-full" data={abciEvents}/>
+          {abciEvents.length !== 0 ? abciEvents.map(({ type, attributes }, i) => (
+            <div key={i} className="flex flex-col sm:items-start items-center w-full gap-y-1">
+              <p className="font-mono whitespace-pre-wrap break-all sm:text-base text-sm pt-5">{type}</p>
+              <ABCIEventsTable className="sm:w-2/3 w-full" data={attributes}/>
+            </div>
+          )) : <p>None</p>}
         </div>
       </div>
     </div>

--- a/src/components/Transaction/index.tsx
+++ b/src/components/Transaction/index.tsx
@@ -35,10 +35,19 @@ const Transaction : FC<TransactionProps> = ({ txData }) => {
             <ReactJson src={penumbraTx.toJson() as object} name={"transaction"} displayDataTypes={false} collapseStringsAfterLength={20} collapsed={5} enableClipboard={true} displayObjectSize={false}/>
           </pre>
         </div>
-        <div className="flex flex-col items-center gap-5 w-full">
+        <div className="flex justify-start flex-wrap w-full">
+          <p className="font-bold text-base">Block Event Attributes</p>
+          {abciEvents.length !== 0 ? abciEvents.map(({ type, attributes }, i) => (
+            <div key={i} className="flex flex-col sm:items-start items-center w-full gap-y-1">
+              <p className="font-mono whitespace-pre-wrap break-all sm:text-base text-sm pt-5">{type}</p>
+              <ABCIEventsTable className="sm:w-2/3 w-full" data={attributes}/>
+            </div>
+          )) : <p>None</p>}
+        </div>
+        {/* <div className="flex flex-col items-center gap-5 w-full">
           <p className="font-semibold">Event Attributes</p>
           <ABCIEventsTable className="w-full" data={abciEvents}/>
-        </div>
+        </div> */}
       </div>
     </div>
   );

--- a/src/lib/validators/search.ts
+++ b/src/lib/validators/search.ts
@@ -122,8 +122,10 @@ export const TransactionResult = z.tuple([
     created_at: z.string().datetime(),
     events: z.array(z.object({
       type: z.string(),
-      value: z.string().nullable(),
-      key: z.string(),
+      attributes: z.array(z.object({
+        value: z.string().nullable(),
+        key: z.string(),
+      })),
     })),
     blocks: z.object({
       height: z.coerce.bigint(),
@@ -144,8 +146,10 @@ export const BlockData = z.object({
   events: z.array(
     z.object({
       type: z.string(),
-      value: z.string().nullable(),
-      key: z.string(),
+      attributes: z.array(z.object({
+        value: z.string().nullable(),
+        key: z.string(),
+      })),
     }),
   ),
   tx_results: z.array(z.object({ tx_hash: z.string() })),


### PR DESCRIPTION
With #21, I had originally flattened the structure of the `events` field into a single record of `type`, `key`, and `value` so that `ABCIEventsTable` was a single table per Block/Transaction. This PR rolls back that change and instead iterates over every ABCI Event of a Block/Transaction and fills out a table of its associated kv attributes.