### PR TITLE
ActionView `Visible` and `Opaque` Variants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
       "dependencies": {
         "@buf/cometbft_cometbft.bufbuild_es": "^1.8.0-20240312114316-c0d3497e35d6.2",
         "@buf/cosmos_ibc.bufbuild_es": "^1.8.0-20240215124455-b32ecf3ebbcb.2",
-        "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.8.0-20240313211643-35db357c277d.2",
+        "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.9.0-20240426013425-8bd0992b1afd.1",
         "@bufbuild/protobuf": "^1.4.2",
         "@connectrpc/connect": "^1.1.3",
         "@microlink/react-json-view": "^1.23.0",
         "@penumbra-zone/getters": "^2.0.0",
+        "@penumbra-zone/types": "^2.0.0",
         "@prisma/client": "^5.4.1",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
@@ -172,90 +173,111 @@
       }
     },
     "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.8.0-20221214150216-75b4300737fb.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.8.0-20221214150216-75b4300737fb.2.tgz",
+      "version": "1.9.0-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.9.0-20221214150216-75b4300737fb.1.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es": {
-      "version": "1.8.0-20240313211643-35db357c277d.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.8.0-20240313211643-35db357c277d.2.tgz",
+      "version": "1.9.0-20240426013425-8bd0992b1afd.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/penumbra-zone_penumbra.bufbuild_es/-/penumbra-zone_penumbra.bufbuild_es-1.9.0-20240426013425-8bd0992b1afd.1.tgz",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.8.0-20211202220400-1935555c206d.2",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.8.0-20230522115704-e7a85cef453e.2",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.8.0-20221020125208-34d970b699f8.2",
-        "@buf/cosmos_ibc.bufbuild_es": "1.8.0-20230913112312-7ab44ae956a0.2",
-        "@buf/cosmos_ics23.bufbuild_es": "1.8.0-20221207100654-55085f7c710a.2",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.8.0-20221214150216-75b4300737fb.2"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.9.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.9.0-20230522115704-e7a85cef453e.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.9.0-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ibc.bufbuild_es": "1.9.0-20230913112312-7ab44ae956a0.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.9.0-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.9.0-20221214150216-75b4300737fb.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_cosmos-proto.bufbuild_es": {
+      "version": "1.9.0-20211202220400-1935555c206d.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-proto.bufbuild_es/-/cosmos_cosmos-proto.bufbuild_es-1.9.0-20211202220400-1935555c206d.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.8.0-20230522115704-e7a85cef453e.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.8.0-20230522115704-e7a85cef453e.2.tgz",
+      "version": "1.9.0-20230522115704-e7a85cef453e.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.9.0-20230522115704-e7a85cef453e.1.tgz",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.8.0-20211202220400-1935555c206d.2",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.8.0-20221020125208-34d970b699f8.2",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.8.0-20221214150216-75b4300737fb.2"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.9.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.9.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.9.0-20221214150216-75b4300737fb.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
+      "version": "1.9.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.9.0-20221020125208-34d970b699f8.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ibc.bufbuild_es": {
-      "version": "1.8.0-20230913112312-7ab44ae956a0.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.8.0-20230913112312-7ab44ae956a0.2.tgz",
+      "version": "1.9.0-20230913112312-7ab44ae956a0.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ibc.bufbuild_es/-/cosmos_ibc.bufbuild_es-1.9.0-20230913112312-7ab44ae956a0.1.tgz",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.8.0-20211202220400-1935555c206d.2",
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.8.0-20230719110346-aa25660f4ff7.2",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.8.0-20221020125208-34d970b699f8.2",
-        "@buf/cosmos_ics23.bufbuild_es": "1.8.0-20221207100654-55085f7c710a.2",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.8.0-20220908150232-8d7204855ec1.2"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.9.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_cosmos-sdk.bufbuild_es": "1.9.0-20230719110346-aa25660f4ff7.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.9.0-20221020125208-34d970b699f8.1",
+        "@buf/cosmos_ics23.bufbuild_es": "1.9.0-20221207100654-55085f7c710a.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.9.0-20220908150232-8d7204855ec1.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.8.0-20230719110346-aa25660f4ff7.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.8.0-20230719110346-aa25660f4ff7.2.tgz",
+      "version": "1.9.0-20230719110346-aa25660f4ff7.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.9.0-20230719110346-aa25660f4ff7.1.tgz",
       "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.8.0-20211202220400-1935555c206d.2",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.8.0-20230509103710-5e5b9fdd0180.2",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.8.0-20230502210827-cc916c318597.2"
+        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.9.0-20211202220400-1935555c206d.1",
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.9.0-20230509103710-5e5b9fdd0180.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.9.0-20230502210827-cc916c318597.1"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
-      "version": "1.8.0-20230509103710-5e5b9fdd0180.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.8.0-20230509103710-5e5b9fdd0180.2.tgz",
+      "version": "1.9.0-20230509103710-5e5b9fdd0180.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.9.0-20230509103710-5e5b9fdd0180.1.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.8.0-20230502210827-cc916c318597.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.8.0-20230502210827-cc916c318597.2.tgz",
+      "version": "1.9.0-20230502210827-cc916c318597.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.9.0-20230502210827-cc916c318597.1.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.8.0-20220908150232-8d7204855ec1.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.8.0-20220908150232-8d7204855ec1.2.tgz",
+      "version": "1.9.0-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.9.0-20220908150232-8d7204855ec1.1.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.8.0"
+        "@bufbuild/protobuf": "^1.9.0"
+      }
+    },
+    "node_modules/@buf/penumbra-zone_penumbra.bufbuild_es/node_modules/@buf/cosmos_ics23.bufbuild_es": {
+      "version": "1.9.0-20221207100654-55085f7c710a.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_ics23.bufbuild_es/-/cosmos_ics23.bufbuild_es-1.9.0-20221207100654-55085f7c710a.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.9.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.8.0.tgz",
-      "integrity": "sha512-qR9FwI8QKIveDnUYutvfzbC21UZJJryYrLuZGjeZ/VGz+vXelUkK+xgkOHsvPEdYEdxtgUUq4313N8QtOehJ1Q=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.9.0.tgz",
+      "integrity": "sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ=="
     },
     "node_modules/@connectrpc/connect": {
       "version": "1.3.0",
@@ -625,6 +647,19 @@
       "dependencies": {
         "@penumbra-zone/bech32": "2.0.0",
         "@penumbra-zone/constants": "2.0.0"
+      }
+    },
+    "node_modules/@penumbra-zone/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@penumbra-zone/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-9kRSXYcLglW1gD/Cwk5Pv6ZI0pwNrf/mBDfpyEofWeRItzIvaAlclHW8BtEddBS2GtPiMxksOrlghdxJD5WRWw==",
+      "dependencies": {
+        "@penumbra-zone/bech32": "2.0.0",
+        "@penumbra-zone/constants": "2.0.0",
+        "@penumbra-zone/getters": "2.0.0",
+        "bignumber.js": "^9.1.2",
+        "idb": "^8.0.0",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@prisma/client": {
@@ -1744,6 +1779,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
       "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -3573,6 +3616,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
+      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw=="
     },
     "node_modules/ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   "dependencies": {
     "@buf/cometbft_cometbft.bufbuild_es": "^1.8.0-20240312114316-c0d3497e35d6.2",
     "@buf/cosmos_ibc.bufbuild_es": "^1.8.0-20240215124455-b32ecf3ebbcb.2",
-    "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.8.0-20240313211643-35db357c277d.2",
+    "@buf/penumbra-zone_penumbra.bufbuild_es": "^1.9.0-20240426013425-8bd0992b1afd.1",
     "@bufbuild/protobuf": "^1.4.2",
     "@connectrpc/connect": "^1.1.3",
     "@microlink/react-json-view": "^1.23.0",
     "@penumbra-zone/getters": "^2.0.0",
+    "@penumbra-zone/types": "^2.0.0",
     "@prisma/client": "^5.4.1",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",

--- a/src/components/ActionView/index.tsx
+++ b/src/components/ActionView/index.tsx
@@ -104,20 +104,20 @@ const Value: FC<{ value: ValueT, label?: string }> = ({ value, label }) => {
 
 const NotePayload: FC<{ notePayload: NotePayloadT }> = ({ notePayload }) => {
   return (
-    <div className="flex">
-      <p>NotePayload</p>
-      <div className="flex">
+    <div className="flex flex-wrap w-full">
+      <p className="w-full">NotePayload</p>
+      <div className="flex flex-wrap w-full">
         {notePayload.noteCommitment ? (
           <div className="flex">
-            <p>Note Commitment</p>
-            <pre>{notePayload.noteCommitment.inner}</pre>
+            <p className="w-full">Note Commitment</p>
+            <pre className="w-full">{notePayload.noteCommitment.inner}</pre>
           </div>
         ) : null}
         <EphemeralKey _key={notePayload.ephemeralKey} name="Ephemeral Key"/>
         {notePayload.encryptedNote ? (
-          <div className="flex">
-            <p>Encrypted Note</p>
-            <pre>{notePayload.encryptedNote.inner}</pre>
+          <div className="flex flex-wrap w-full">
+            <p className="w-full">Encrypted Note</p>
+            <pre className="w-full">{notePayload.encryptedNote.inner}</pre>
           </div>
         ) : null}
       </div>
@@ -129,10 +129,10 @@ const NotePayload: FC<{ notePayload: NotePayloadT }> = ({ notePayload }) => {
 const Output: FC<{ output: OutputT }> = ({ output }) => {
   const body = output.body;
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col flex-wrap w-full">
       {body ? (
-        <div className="flex">
-          <p>OutputBody</p>
+        <div className="flex flex-wrap w-full">
+          <p className="w-full">OutputBody</p>
           {body.notePayload ? (
             <NotePayload notePayload={body.notePayload}/>
           ) : null}
@@ -144,9 +144,9 @@ const Output: FC<{ output: OutputT }> = ({ output }) => {
         </div>
       ) : null}
       {output.proof ? (
-        <div className="flex">
-          <p>Proof</p>
-          <pre>{output.proof.inner}</pre>
+        <div className="flex flex-wrap w-full">
+          <p className="w-full">Proof</p>
+          <pre className="w-full">{output.proof.inner}</pre>
         </div>
       ) : null}
     </div>
@@ -156,33 +156,33 @@ const Output: FC<{ output: OutputT }> = ({ output }) => {
 const Spend : FC<{spend: SpendT}>= ({spend}) => {
   const spendBody = spend.body;
   return (
-    <div className="flex flex-col">
-      <div className="flex flex-col">
+    <div className="flex flex-col flex-wrap w-full">
+      <div className="flex flex-col flex-wrap w-full">
         {spend.proof ? (
-          <div className="flex">
-            <p>Proof</p>
-            <pre>{spend.proof.inner}</pre>
+          <div className="flex flex-wrap w-full">
+            <p className="w-full">Proof</p>
+            <pre className="w-full">{spend.proof.inner}</pre>
           </div>
         ) : null}
         {spend.authSig ? (
-        <div className="flex">
-          <p>AuthSig</p>
-          <pre>{spend.authSig.inner}</pre>
+        <div className="flex flex-wrap w-full">
+          <p className="w-full">AuthSig</p>
+          <pre className="w-full">{spend.authSig.inner}</pre>
         </div>
         ) : null}
         {spendBody ? (
-          <div className="flex">
-            <p>Body</p>
-            <div className="flex">
+          <div className="flex flex-wrap w-full">
+            <p className="w-full">Body</p>
+            <div className="flex flex-wrap w-full">
               {spendBody.nullifier ? (
-                <div className="flex">
-                  <p>Nullifier</p>
-                  <pre>{spendBody.nullifier.inner}</pre>
+                <div className="flex flex-wrap w-full">
+                  <p className="w-full">Nullifier</p>
+                  <pre className="w-full">{spendBody.nullifier.inner}</pre>
                 </div>
               ) : spendBody.rk ? (
-                <div className="flex">
-                  <p>Randomized Validating Key</p>
-                  <pre>{spendBody.rk.inner}</pre>
+                <div className="flex flex-wrap w-full">
+                  <p className="w-full">Randomized Validating Key</p>
+                  <pre className="w-full">{spendBody.rk.inner}</pre>
                 </div>
               ) : <p>None</p>}
             </div>
@@ -242,18 +242,18 @@ const NoteView : FC<{note: NoteViewT}>= ({ note }) => {
   const addressIndex = getAddressIndex.optional()(note.address);
 
   return (
-    <div className="flex flex-col">
-      <p>TxNote</p>
+    <div className="flex flex-col flex-wrap w-full">
+      <p className="w-full">TxNote</p>
       {address ? (
-        <div className="flex flex-col">
-          <p>Address</p>
+        <div className="flex flex-col flex-wrap w-full">
+          <p className="w-full">Address</p>
           <Address address={address}/>
           {walletId ? <WalletId walletId={walletId}/> : null}
           {addressIndex ? <AddressIndex index={addressIndex}/> : null}
         </div>
       ) : null}
-      <div className="flex flex-col">
-        <p>rseed</p>
+      <div className="flex flex-col flex-wrap">
+        <p className="w-full">rseed</p>
         <pre>{note.rseed}</pre>
       </div>
     </div>
@@ -262,8 +262,8 @@ const NoteView : FC<{note: NoteViewT}>= ({ note }) => {
 
 const SpendView : FC<{ spend: SpendT, noteView?: NoteViewT}> = ({spend, noteView}) => {
   return (
-    <div className="flex flex-col">
-      <p>Spend View</p>
+    <div className="flex flex-col flex-wrap w-full">
+      <p className="w-full">Spend View</p>
       <Spend spend={spend} />
       {noteView ? (
         <NoteView note={noteView}/>
@@ -274,8 +274,8 @@ const SpendView : FC<{ spend: SpendT, noteView?: NoteViewT}> = ({spend, noteView
 
 const OutputView: FC<{ output: OutputT, noteView?: NoteViewT, payloadKey?: PayloadKeyT }> = ({ output, noteView, payloadKey }) => {
   return (
-    <div className="flex flex-col">
-      <p>Output View</p>
+    <div className="flex flex-col flex-wrap w-full">
+      <p className="w-full">Output View</p>
       <Output output={output} />
       {noteView ? (
         <NoteView note={noteView}/>
@@ -684,7 +684,7 @@ interface ActionViewProps {
 
 export const ActionView : FC<ActionViewProps> = ({ action }) => {
   return (
-    <div className="flex flex-wrap w-full">
+    <div className="flex flex-col flex-wrap w-full">
       {getActionView(action)}
     </div>
   );

--- a/src/components/ActionView/index.tsx
+++ b/src/components/ActionView/index.tsx
@@ -1,16 +1,15 @@
 import type { FC } from "react";
-import type { SwapView as SwapViewT, SwapClaimView as SwapClaimViewT, Swap as SwapT, TradingPair as TradingPairT, SwapPayload as SwapPayloadT, SwapView_Visible, BatchSwapOutputData as BatchSwapOutputDataT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import type { SwapView as SwapViewT, SwapClaimView as SwapClaimViewT, Swap as SwapT, TradingPair as TradingPairT, SwapPayload as SwapPayloadT, SwapView_Visible, BatchSwapOutputData as BatchSwapOutputDataT, SwapPlaintext as SwapPlaintextT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import type { Output as OutputT, NoteView as NoteViewT, Spend as SpendT, NotePayload as NotePayloadT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb";
 import type { ActionView as ActionViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { type DelegatorVoteView, DelegatorVoteView_Opaque, type DelegatorVoteView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 import { getAddress, getAddressIndex } from "@penumbra-zone/getters/src/address-view";
 import { getAsset1, getAsset2 } from "@penumbra-zone/getters/src/trading-pair";
-import { getDelta1Amount, getDelta2Amount, getTradingPair, getLambda1Amount, getLambda2Amount, getUnfilled1Amount, getUnfilled2Amount } from "@penumbra-zone/getters/src/batch-swap-output-data";
+import { getBatchSwapOutputDelta1Amount, getBatchSwapOutputDelta2Amount, getBatchSwapOutputTradingPair, getBatchSwapOutputLambda1Amount, getBatchSwapOutputLambda2Amount, getBatchSwapOutputUnfilled1Amount, getBatchSwapOutputUnfilled2Amount , getBatchSwapOutputData, getOutput, getOutputKey, getOutputNote, getSpend, getSpendNote, getSwap, getSwapBodyAmounts, getSwapBodyFeeCommitment, getSwapBodyPayload, getSwapMetadata1, getSwapMetadata2, getWalletId, getOutputValue1FromSwapView, getOutputValue2FromSwapView, getSwapTransactionId, getSwapPlainText, getSwapNoteViewOutput1, getSwapNoteViewOutput2 } from "@/lib/protobuf";
 import { joinLoHiAmount } from "@penumbra-zone/types/src/amount";
 import { getAssetId } from "@penumbra-zone/getters/src/metadata";
 import { getAmount, getMetadata, getEquivalentValues, getExtendedMetadata, getAssetIdFromValueView } from "@penumbra-zone/getters/src/value-view";
 import type { Address as AddressT, AddressIndex as AddressIndexT, WalletId as WalletIdT, PayloadKey as PayloadKeyT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
-import { getBatchSwapOutputData, getOutput, getOutputKey, getOutputNote, getSpend, getSpendNote, getSwap, getSwapBodyAmounts, getSwapBodyFeeCommitment, getSwapBodyPayload, getSwapMetadata1, getSwapMetadata2, getWalletId, getOutputValue1FromSwapView, getOutputValue2FromSwapView } from "@/lib/protobuf";
 import type { AssetId as AssetIdT, EquivalentValue as EquivalentValueT, Metadata as MetadataT, ValueView as ValueViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb";
 import { FlexCol, FlexRow } from "../ui/flex";
 import type { Amount as AmountT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb";
@@ -285,7 +284,7 @@ const OutputView: FC<{ output: OutputT, noteView?: NoteViewT, payloadKey?: Paylo
 const AssetId: FC<{ assetId: AssetIdT, label?: string }> = ({ assetId, label }) => {
   return (
     <FlexRow>
-      {label ? <p>{label}</p> : <p>Asset ID</p>}
+      {(label ?? "") ? <p>{label}</p> : <p>Asset ID</p>}
       <FlexRow>
         <p>inner</p>
         <p>{assetId.inner}</p>
@@ -333,13 +332,13 @@ const SwapPayload: FC<{ swapPayload: SwapPayloadT }> = ({ swapPayload }) => {
 };
 
 const BatchSwapOutputData: FC<{ batchSwapOutput: BatchSwapOutputDataT }> = ({ batchSwapOutput }) => {
-  const delta1I = getDelta1Amount(batchSwapOutput);
-  const delta2I = getDelta2Amount(batchSwapOutput);
-  const lambda1 = getLambda1Amount(batchSwapOutput);
-  const lambda2 = getLambda2Amount(batchSwapOutput);
-  const unfilled1 = getUnfilled1Amount(batchSwapOutput);
-  const unfilled2 = getUnfilled2Amount(batchSwapOutput);
-  const tradingPair = getTradingPair(batchSwapOutput);
+  const delta1I = getBatchSwapOutputDelta1Amount(batchSwapOutput);
+  const delta2I = getBatchSwapOutputDelta2Amount(batchSwapOutput);
+  const lambda1 = getBatchSwapOutputLambda1Amount(batchSwapOutput);
+  const lambda2 = getBatchSwapOutputLambda2Amount(batchSwapOutput);
+  const unfilled1 = getBatchSwapOutputUnfilled1Amount(batchSwapOutput);
+  const unfilled2 = getBatchSwapOutputUnfilled2Amount(batchSwapOutput);
+  const tradingPair = getBatchSwapOutputTradingPair(batchSwapOutput);
   const height = batchSwapOutput.height;
   const startingEpoch = batchSwapOutput.epochStartingHeight;
   return (
@@ -403,6 +402,15 @@ const Metadata: FC<{ metaData: MetadataT, label?: "Asset 1" | "Asset 2" }> = ({ 
   );
 };
 
+const SwapPlaintext: FC<{ swapPlaintext: SwapPlaintextT }> = ({ swapPlaintext }) => {
+
+  return (
+    <FlexCol>
+
+    </FlexCol>
+  );
+};
+
 const Swap: FC<{ swap: SwapT}> = ({ swap }) => {
   const swapBody = swap.body;
   const { delta1I, delta2I } = getSwapBodyAmounts(swapBody);
@@ -427,8 +435,8 @@ const Swap: FC<{ swap: SwapT}> = ({ swap }) => {
 
 const SwapViewOpaque: FC<{ swapView: SwapViewT }> = ({ swapView }) => {
   const batchSwapOutput = getBatchSwapOutputData.optional()(swapView);
-  const metaData1 = getSwapMetadata1.optional()(swapView);
-  const metaData2 = getSwapMetadata2.optional()(swapView);
+  const metadata1 = getSwapMetadata1.optional()(swapView);
+  const metadata2 = getSwapMetadata2.optional()(swapView);
   const outputValue1 = getOutputValue1FromSwapView.optional()(swapView);
   const outputValue2 = getOutputValue2FromSwapView.optional()(swapView);
   return (
@@ -436,28 +444,38 @@ const SwapViewOpaque: FC<{ swapView: SwapViewT }> = ({ swapView }) => {
       {batchSwapOutput ? <BatchSwapOutputData batchSwapOutput={batchSwapOutput}/> : null}
       {outputValue1 ? <ValueView valueView={outputValue1} label="Asset 1"/> : null}
       {outputValue2 ? <ValueView valueView={outputValue2} label="Asset 2"/> : null}
-      {metaData1 ? <Metadata metaData={metaData1} label="Asset 1"/> : null}
-      {metaData2 ? <Metadata metaData={metaData2} label="Asset 2"/> : null}
+      {metadata1 ? <Metadata metaData={metadata1} label="Asset 1"/> : null}
+      {metadata2 ? <Metadata metaData={metadata2} label="Asset 2"/> : null}
     </FlexCol>
   );
 };
 
-const SwapViewVisible: FC<{ swapViewVisible: SwapView_Visible }> = ({ swapViewVisible }) => {
+const SwapViewVisible: FC<{ swapView: SwapViewT }> = ({ swapView }) => {
+  const swapPlaintext = getSwapPlainText(swapView);
+  const transactionId = getSwapTransactionId.optional()(swapView);
+  const batchSwapOutput = getBatchSwapOutputData.optional()(swapView);
+  const noteOuput1 = getSwapNoteViewOutput1.optional()(swapView);
+  const noteOuput2 = getSwapNoteViewOutput2.optional()(swapView);
+  const metadata1 = getSwapMetadata1.optional()(swapView);
+  const metadata2 = getSwapMetadata2.optional()(swapView);
   return (
-    <div></div>
+    <FlexCol>
+    </FlexCol>
   );
 };
 
 const SwapView: FC<{ swapView: SwapViewT }> = ({ swapView }) => {
+  // NOTE: everything but Swap itself and SwapPlaintext (for SwapView_Visible) are optional.
+  //       While less than hygenic, it would theoretically be fine to just have all getters defined here
+  //       and render purely on ternary checks. SwapPlaintext would be made optional but would only render
+  //       if a SwapView_Visible, etc.
   const swap = getSwap(swapView);
-
-
   return (
     <FlexCol>
       <p>Swap View</p>
       <Swap swap={swap}/>
       {swapView.swapView.case === "visible" ? (
-        <SwapViewVisible swapViewVisible={swapView.swapView.value}/>
+        <SwapViewVisible swapView={swapView}/>
       ) : swapView.swapView.case === "opaque" ? (
         <SwapViewOpaque swapView={swapView}/>
       ) : null}

--- a/src/components/ActionView/index.tsx
+++ b/src/components/ActionView/index.tsx
@@ -2,29 +2,18 @@ import type { FC } from "react";
 import type { SwapView as SwapViewT, SwapClaimView as SwapClaimViewT, Swap as SwapT, TradingPair as TradingPairT, SwapPayload as SwapPayloadT, BatchSwapOutputData as BatchSwapOutputDataT, SwapPlaintext as SwapPlaintextT, SwapClaim as SwapClaimT} from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import type { Output as OutputT, NoteView as NoteViewT, Spend as SpendT, NotePayload as NotePayloadT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb";
 import type { ActionView as ActionViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
-import { type DelegatorVoteView, DelegatorVoteView_Opaque, type DelegatorVoteView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
+import type { DelegatorVoteView as DelegatorVoteViewT, Vote as VoteT, } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 import { getAddress, getAddressIndex } from "@penumbra-zone/getters/src/address-view";
 import { getAsset1, getAsset2 } from "@penumbra-zone/getters/src/trading-pair";
-import { getBatchSwapOutputDelta1Amount, getBatchSwapOutputDelta2Amount, getBatchSwapOutputTradingPair, getBatchSwapOutputLambda1Amount, getBatchSwapOutputLambda2Amount, getBatchSwapOutputUnfilled1Amount, getBatchSwapOutputUnfilled2Amount , getBatchSwapOutputData, getOutput, getOutputKey, getOutputNote, getSpend, getSpendNote, getSwap, getSwapBodyAmounts, getSwapBodyFeeCommitment, getSwapBodyPayload, getSwapMetadata1, getSwapMetadata2, getWalletId, getOutputValue1FromSwapView, getOutputValue2FromSwapView, getSwapTransactionId, getSwapPlaintext, getSwapNoteViewOutput1, getSwapNoteViewOutput2, getSwapPlaintextTradingPair, getSwapPlaintextDelta1, getSwapPlaintextDelta2, getSwapPlaintextFee, getSwapPlaintextAddress, getFeeAmount, getFeeAssetId, getSwapClaimViewZKProof, getSwapClaimViewBody, getSwapClaimViewEpochDuration, getSwapClaimBodyNullifier, getSwapClaimBodyFee, getSwapClaimBodyOutput1Commitment, getSwapClaimBodyOutput2Commitment, getSwapClaimBodyBatchOutputData, getSwapClaimNoteOutput1, getSwapClaimNoteOutput2, getSwapClaimTransactionId } from "@/lib/protobuf";
+import { getBatchSwapOutputDelta1Amount, getBatchSwapOutputDelta2Amount, getBatchSwapOutputTradingPair, getBatchSwapOutputLambda1Amount, getBatchSwapOutputLambda2Amount, getBatchSwapOutputUnfilled1Amount, getBatchSwapOutputUnfilled2Amount , getBatchSwapOutputData, getOutput, getOutputKey, getOutputNote, getSpend, getSpendNote, getSwap, getSwapBodyAmounts, getSwapBodyFeeCommitment, getSwapBodyPayload, getSwapMetadata1, getSwapMetadata2, getWalletId, getOutputValue1FromSwapView, getOutputValue2FromSwapView, getSwapTransactionId, getSwapPlaintext, getSwapNoteViewOutput1, getSwapNoteViewOutput2, getSwapPlaintextTradingPair, getSwapPlaintextDelta1, getSwapPlaintextDelta2, getSwapPlaintextFee, getSwapPlaintextAddress, getFeeAmount, getFeeAssetId, getSwapClaimViewZKProof, getSwapClaimViewBody, getSwapClaimViewEpochDuration, getSwapClaimBodyNullifier, getSwapClaimBodyFee, getSwapClaimBodyOutput1Commitment, getSwapClaimBodyOutput2Commitment, getSwapClaimBodyBatchOutputData, getSwapClaimNoteOutput1, getSwapClaimNoteOutput2, getSwapClaimTransactionId, getDelegatorVoteViewBody, getDelegatorVoteViewAuthSig, getDelegatorVoteViewProof, getDelegatorVoteViewNote, getDelegatorVoteBodyProposal, getDelegatorVoteBodyStartPosition, getDelegatorVoteBodyVote, getDelegatorVoteBodyValue, getDelegatorVoteBodyUnbondedAmount, getDelegatorVoteBodyNullifier, getDelegatorVoteBodyRK } from "@/lib/protobuf";
 import { joinLoHiAmount } from "@penumbra-zone/types/src/amount";
 import { getAssetId } from "@penumbra-zone/getters/src/metadata";
 import { getAmount, getMetadata, getEquivalentValues, getExtendedMetadata, getAssetIdFromValueView } from "@penumbra-zone/getters/src/value-view";
 import type { Address as AddressT, AddressIndex as AddressIndexT, WalletId as WalletIdT, PayloadKey as PayloadKeyT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
-import type { AssetId as AssetIdT, EquivalentValue as EquivalentValueT, Metadata as MetadataT, ValueView as ValueViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb";
+import type { AssetId as AssetIdT, EquivalentValue as EquivalentValueT, Metadata as MetadataT, Value as ValueT, ValueView as ValueViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb";
 import { FlexCol, FlexRow } from "../ui/flex";
 import type { Amount as AmountT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/num/v1/num_pb";
 import type { Fee as FeeT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1/fee_pb";
-
-const getDelegatorVoteView = ({ delegatorVote } : DelegatorVoteView) : DelegatorVoteView_Opaque | DelegatorVoteView_Visible => {
-  switch (delegatorVote.case) {
-    case "opaque":
-      return delegatorVote.value;
-    case "visible":
-      return delegatorVote.value;
-    default:
-      throw new Error("DelegatorVoteView exhaustive check failed. This should be impossible.");
-  }
-};
 
 const PayloadKey: FC<{ payloadKey: PayloadKeyT }> = ({ payloadKey }) => {
   return (
@@ -54,6 +43,9 @@ const EncryptedSwap = GenericKV;
 const RSeed = GenericKV;
 const TransactionId = GenericKV;
 const Nullifier = GenericKV;
+const SpendAuthSignature = GenericKV;
+const SpendVerificationKey = GenericKV;
+const ZKDelegatorVoteProof = GenericKV;
 
 const EquivalentValueView: FC<{ equivalentValue: EquivalentValueT }> = ({ equivalentValue }) => {
   return (
@@ -79,7 +71,7 @@ const ValueView: FC<{ valueView: ValueViewT, label?: "Asset 1" | "Asset 2" }> = 
   const assetId = getAssetIdFromValueView(valueView);
   return (
     <FlexCol>
-      {label ? <p>{label} Value</p> : <p>Value</p>}
+      {label ? <p>{label} ValueView</p> : <p>ValueView</p>}
       <Amount amount={amount} label={label ? `${label} Amount` : "Amount"}/>
       {metadata ? <Metadata metaData={metadata} label={label}/> : null}
       {equivalentValues ? (
@@ -96,6 +88,16 @@ const ValueView: FC<{ valueView: ValueViewT, label?: "Asset 1" | "Asset 2" }> = 
       {valueView.valueView.case === "unknownAssetId" ? (
         <AssetId assetId={assetId}/>
       ) : null}
+    </FlexCol>
+  );
+};
+
+const Value: FC<{ value: ValueT, label?: string }> = ({ value, label }) => {
+  return (
+    <FlexCol>
+      {(label ?? "") ? <p>{label}</p> : <p>Value</p>}
+      {value.amount ? <Amount amount={value.amount}/> : null}
+      {value.assetId ? <AssetId assetId={value.assetId}/> : null}
     </FlexCol>
   );
 };
@@ -406,6 +408,15 @@ const Metadata: FC<{ metaData: MetadataT, label?: "Asset 1" | "Asset 2" }> = ({ 
   );
 };
 
+const Vote: FC<{ vote: VoteT }> = ({ vote }) => {
+  return (
+    <FlexRow>
+      <p>Vote</p>
+      <pre>{vote.vote.toString()}</pre>
+    </FlexRow>
+  );
+};
+
 const Fee: FC<{ fee: FeeT}> = ({ fee }) => {
   const amount = getFeeAmount(fee);
   const assetId = getFeeAssetId.optional()(fee);
@@ -526,8 +537,8 @@ const SwapClaimView: FC<{ swapClaimView: SwapClaimViewT}> = ({ swapClaimView }) 
   // SwapClaimBody fields
   const bodyNullifier = getSwapClaimBodyNullifier.optional()(swapClaimView);
   const bodyFee = getSwapClaimBodyFee.optional()(swapClaimView);
-  const bodyOutput1Commitment = getSwapClaimBodyOutput1Commitment.optional()(swapClaimView)
-  const bodyOutput2Commitment = getSwapClaimBodyOutput2Commitment.optional()(swapClaimView)
+  const bodyOutput1Commitment = getSwapClaimBodyOutput1Commitment.optional()(swapClaimView);
+  const bodyOutput2Commitment = getSwapClaimBodyOutput2Commitment.optional()(swapClaimView);
   const bodyOutputData = getSwapClaimBodyBatchOutputData.optional()(swapClaimView);
   // SwapClaimView_Visible fields
   const isVisible = swapClaimView.swapClaimView.case === "visible";
@@ -563,6 +574,57 @@ const SwapClaimView: FC<{ swapClaimView: SwapClaimViewT}> = ({ swapClaimView }) 
   );
 };
 
+const DelegatorVoteView: FC<{ delegatorVoteView: DelegatorVoteViewT }> = ({ delegatorVoteView }) => {
+  // DelegatorVoteView fields
+  const delegatorVoteBody = getDelegatorVoteViewBody.optional()(delegatorVoteView);
+  const delegatorVoteAuthSig = getDelegatorVoteViewAuthSig.optional()(delegatorVoteView);
+  const delegatorVoteProof = getDelegatorVoteViewProof.optional()(delegatorVoteView);
+  // DelegatorVoteBody fields
+  // StartPosition and Proposal are the only non-optional fields but they're embedded in DelegatorVoteBody which, itself, is optional.
+  const bodyProposal = getDelegatorVoteBodyProposal.optional()(delegatorVoteView);
+  const bodyStartPosition = getDelegatorVoteBodyStartPosition.optional()(delegatorVoteView);
+  const bodyVote = getDelegatorVoteBodyVote.optional()(delegatorVoteView);
+  const bodyValue = getDelegatorVoteBodyValue.optional()(delegatorVoteView);
+  const bodyUnboundedAmount = getDelegatorVoteBodyUnbondedAmount.optional()(delegatorVoteView);
+  const bodyNullifier = getDelegatorVoteBodyNullifier.optional()(delegatorVoteView);
+  const bodyRK = getDelegatorVoteBodyRK.optional()(delegatorVoteView);
+  // DelegatorVoteView_Visible fields
+  const isVisible = delegatorVoteView.delegatorVote.case === "visible";
+  const delegatorVoteViewNote = getDelegatorVoteViewNote.optional()(delegatorVoteView);
+  return (
+    <FlexCol>
+      <p>Delegator Vote View</p>
+      <FlexCol>
+        {delegatorVoteBody ? (
+          <FlexCol>
+            <p>DelegatorVoteBody</p>
+            {bodyProposal !== undefined ? (
+              <FlexRow>
+                <p>Proposal</p>
+                <pre>{bodyProposal.toString()}</pre>
+              </FlexRow>
+            ) : null}
+            {bodyStartPosition !== undefined ? (
+              <FlexRow>
+                <p>Proposal</p>
+                <pre>{bodyStartPosition.toString()}</pre>
+            </FlexRow>
+            ) : null}
+            {bodyVote ? <Vote vote={bodyVote}/> : null}
+            {bodyValue ? <Value value={bodyValue} label="Delegation Note Value"/> : null}
+            {bodyUnboundedAmount ? <Amount amount={bodyUnboundedAmount} label="Delegation Note Amount"/> : null}
+            {bodyNullifier ? <Nullifier _key={bodyNullifier.inner} name="Input Note Nullifier"/> : null}
+            {bodyRK ? <SpendVerificationKey _key={bodyRK.inner} name="Validating Key"/> : null}
+          </FlexCol>
+        ) : null}
+        {delegatorVoteAuthSig ? <SpendAuthSignature _key={delegatorVoteAuthSig.inner} name="Auth Signature"/> : null}
+        {delegatorVoteProof ? <ZKDelegatorVoteProof _key={delegatorVoteProof.inner} name="Delegator Vote Proof"/> : null}
+      </FlexCol>
+      {isVisible && delegatorVoteViewNote ? <NoteView note={delegatorVoteViewNote}/> : null}
+    </FlexCol>
+  );
+};
+
 export const getActionView = ({ actionView } : ActionViewT) => {
   switch (actionView.case) {
     case "spend": {
@@ -583,18 +645,7 @@ export const getActionView = ({ actionView } : ActionViewT) => {
       return <SwapClaimView swapClaimView={actionView.value}/>;
     }
     case "delegatorVote": {
-      const outputView = getDelegatorVoteView(actionView.value);
-      if (outputView instanceof DelegatorVoteView_Opaque) {
-        return (
-          <div>
-          </div>
-        );
-      } else {
-        return (
-          <div>
-          </div>
-        );
-      }
+      return <DelegatorVoteView delegatorVoteView={actionView.value}/>;
     }
     case "validatorDefinition": {
       return (

--- a/src/components/ActionView/index.tsx
+++ b/src/components/ActionView/index.tsx
@@ -1,23 +1,12 @@
-import { type FC } from "react";
-import { type SwapView, SwapView_Opaque, type SwapClaimView, SwapClaimView_Opaque, type SwapView_Visible, type SwapClaimView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
-import type { Output as OutputSchema, NoteView as NoteViewSchema, Spend as SpendSchema, NotePayload as NotePayloadSchema } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb";
-import type { ActionView as ActionViewSchema } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
+import type { FC } from "react";
+import type { SwapView as SwapViewT, SwapClaimView as SwapClaimViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import type { Output as OutputT, NoteView as NoteViewT, Spend as SpendT, NotePayload as NotePayloadT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/shielded_pool/v1/shielded_pool_pb";
+import type { ActionView as ActionViewT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { type DelegatorVoteView, DelegatorVoteView_Opaque, type DelegatorVoteView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 import { getAddress, getAddressIndex } from "@penumbra-zone/getters/src/address-view";
-import type { Address as AddressSchema, AddressIndex as AddressIndexSchema, WalletId as WalletIdSchema, PayloadKey as PayloadKeySchema } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
+import type { Address as AddressT, AddressIndex as AddressIndexT, WalletId as WalletIdT, PayloadKey as PayloadKeyT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { getOutput, getOutputKey, getOutputNote, getSpend, getSpendNote, getWalletId } from "@/lib/protobuf";
-import type { BalanceCommitment as BalanceCommitmentSchema } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb";
-
-const getSwapView = ({ swapView } : SwapView) : SwapView_Opaque | SwapView_Visible => {
-  switch (swapView.case) {
-    case "opaque":
-      return swapView.value;
-    case "visible":
-      return swapView.value;
-    default:
-      throw new Error("SwapView exhaustive check failed. This should be impossible.");
-  }
-};
+import type { BalanceCommitment as BalanceCommitmentT } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb";
 
 const getDelegatorVoteView = ({ delegatorVote } : DelegatorVoteView) : DelegatorVoteView_Opaque | DelegatorVoteView_Visible => {
   switch (delegatorVote.case) {
@@ -30,18 +19,7 @@ const getDelegatorVoteView = ({ delegatorVote } : DelegatorVoteView) : Delegator
   }
 };
 
-const getSwapClaimView = ({ swapClaimView } : SwapClaimView) : SwapClaimView_Opaque | SwapClaimView_Visible => {
-  switch (swapClaimView.case) {
-    case "opaque":
-      return swapClaimView.value;
-    case "visible":
-      return swapClaimView.value;
-    default:
-      throw new Error("SwapClaimView exhaustive check failed. This should be impossible.");
-  }
-};
-
-const PayloadKey: FC<{ payloadKey: PayloadKeySchema }> = ({ payloadKey }) => {
+const PayloadKey: FC<{ payloadKey: PayloadKeyT }> = ({ payloadKey }) => {
   return (
     <div className="flex">
       <p>Payload Key</p>
@@ -63,7 +41,7 @@ const OvkWrappedKey = GenericKey;
 const WrappedMemoKey = GenericKey;
 const EphemeralKey = GenericKey;
 
-const NotePayload: FC<{ notePayload: NotePayloadSchema }> = ({ notePayload }) => {
+const NotePayload: FC<{ notePayload: NotePayloadT }> = ({ notePayload }) => {
   return (
     <div className="flex">
       <p>NotePayload</p>
@@ -86,7 +64,7 @@ const NotePayload: FC<{ notePayload: NotePayloadSchema }> = ({ notePayload }) =>
   );
 };
 
-const BalanceCommittment: FC<{ balance: BalanceCommitmentSchema }> = ({ balance }) => {
+const BalanceCommittment: FC<{ balance: BalanceCommitmentT }> = ({ balance }) => {
   return (
     <div className="flex">
       <p>Balance Commitment</p>
@@ -95,7 +73,7 @@ const BalanceCommittment: FC<{ balance: BalanceCommitmentSchema }> = ({ balance 
   );
 };
 
-const Output: FC<{ output: OutputSchema }> = ({ output }) => {
+const Output: FC<{ output: OutputT }> = ({ output }) => {
   const body = output.body;
   return (
     <div className="flex flex-col">
@@ -122,7 +100,7 @@ const Output: FC<{ output: OutputSchema }> = ({ output }) => {
   );
 };
 
-const Spend : FC<{spend: SpendSchema}>= ({spend}) => {
+const Spend : FC<{spend: SpendT}>= ({spend}) => {
   const spendBody = spend.body;
   return (
     <div className="flex flex-col">
@@ -162,7 +140,7 @@ const Spend : FC<{spend: SpendSchema}>= ({spend}) => {
   );
 };
 
-const Address :FC<{ address: AddressSchema }> = ({ address }) => {
+const Address :FC<{ address: AddressT }> = ({ address }) => {
   return (
     <div className="flex flex-col">
       <div className="flex">
@@ -177,7 +155,7 @@ const Address :FC<{ address: AddressSchema }> = ({ address }) => {
   );
 };
 
-const AddressIndex : FC<{ index: AddressIndexSchema }> = ({ index }) => {
+const AddressIndex : FC<{ index: AddressIndexT }> = ({ index }) => {
   return (
     <div className="flex flex-col">
       <div className="flex">
@@ -192,7 +170,7 @@ const AddressIndex : FC<{ index: AddressIndexSchema }> = ({ index }) => {
   );
 };
 
-const WalletId : FC<{ walletId: WalletIdSchema }> = ({ walletId }) => {
+const WalletId : FC<{ walletId: WalletIdT }> = ({ walletId }) => {
   return (
     <div className="flex flex-col">
       <p>WalletID</p>
@@ -205,7 +183,7 @@ const WalletId : FC<{ walletId: WalletIdSchema }> = ({ walletId }) => {
 };
 
 
-const NoteView : FC<{note: NoteViewSchema}>= ({ note }) => {
+const NoteView : FC<{note: NoteViewT}>= ({ note }) => {
   const address = getAddress.optional()(note.address);
   const walletId = getWalletId.optional()(note.address);
   const addressIndex = getAddressIndex.optional()(note.address);
@@ -217,7 +195,7 @@ const NoteView : FC<{note: NoteViewSchema}>= ({ note }) => {
         <div className="flex flex-col">
           <p>Address</p>
           <Address address={address}/>
-          {walletId !== undefined ? <WalletId walletId={walletId}/> : null}
+          {walletId ? <WalletId walletId={walletId}/> : null}
           {addressIndex ? <AddressIndex index={addressIndex}/> : null}
         </div>
       ) : null}
@@ -229,19 +207,19 @@ const NoteView : FC<{note: NoteViewSchema}>= ({ note }) => {
   );
 };
 
-const SpendView : FC<{ spend: SpendSchema, noteView?: NoteViewSchema}> = ({spend, noteView}) => {
+const SpendView : FC<{ spend: SpendT, noteView?: NoteViewT}> = ({spend, noteView}) => {
   return (
     <div className="flex flex-col">
       <p>Spend View</p>
       <Spend spend={spend} />
-      {noteView !== undefined ? (
+      {noteView ? (
         <NoteView note={noteView}/>
       ) : null}
     </div>
   );
 };
 
-const OutputView: FC<{ output: OutputSchema, noteView?: NoteViewSchema, payloadKey?: PayloadKeySchema }> = ({ output, noteView, payloadKey }) => {
+const OutputView: FC<{ output: OutputT, noteView?: NoteViewT, payloadKey?: PayloadKeyT }> = ({ output, noteView, payloadKey }) => {
   return (
     <div className="flex flex-col">
       <p>Output View</p>
@@ -256,7 +234,7 @@ const OutputView: FC<{ output: OutputSchema, noteView?: NoteViewSchema, payloadK
   );
 };
 
-export const getActionView = ({ actionView } : ActionViewSchema) => {
+export const getActionView = ({ actionView } : ActionViewT) => {
   switch (actionView.case) {
     case "spend": {
       const spendView = getSpend(actionView.value);
@@ -270,32 +248,10 @@ export const getActionView = ({ actionView } : ActionViewSchema) => {
       return <OutputView output={outputView} noteView={noteView} payloadKey={outputKey}/>;
     }
     case "swap": {
-      const outputView = getSwapView(actionView.value);
-      if (outputView instanceof SwapView_Opaque) {
-        return (
-          <div>
-          </div>
-        );
-      } else {
-        return (
-          <div>
-          </div>
-        );
-      }
+      return undefined;
     }
     case "swapClaim": {
-      const outputView = getSwapClaimView(actionView.value);
-      if (outputView instanceof SwapClaimView_Opaque) {
-        return (
-          <div>
-          </div>
-        );
-      } else {
-        return (
-          <div>
-          </div>
-        );
-      }
+      return undefined;
     }
     case "delegatorVote": {
       const outputView = getDelegatorVoteView(actionView.value);
@@ -342,7 +298,7 @@ export const getActionView = ({ actionView } : ActionViewSchema) => {
 };
 
 interface ActionViewProps {
-  action: ActionViewSchema,
+  action: ActionViewT,
 }
 
 

--- a/src/components/TransactionView/TransactionBodyView/index.tsx
+++ b/src/components/TransactionView/TransactionBodyView/index.tsx
@@ -9,7 +9,7 @@ interface TransactionBodyViewProps {
 export const TransactionBodyView : FC<TransactionBodyViewProps> = ({ bodyView }) => {
   return (
     <div className="flex flex-col sm:items-start items-center w-full gap-y-1">
-      <p>Action Views</p>
+      <p className="w-full">Action Views</p>
       {bodyView.actionViews.length !== 0 ?
         bodyView.actionViews.map((action, i) => (<ActionView key={i} action={action}/>))
       : null}

--- a/src/components/TransactionView/index.tsx
+++ b/src/components/TransactionView/index.tsx
@@ -37,13 +37,13 @@ export const TransactionView : FC<TransactionViewProps> = ({ tx }) => {
   return (
     <div className="flex flex-col sm:items-start items-center w-full gap-y-1">
       <div>
-        <p className="text-sm font-semibold">TxBodyView</p>
+        <p className="text-sm font-semibold">TransactionBodyView</p>
         {txView.bodyView ? (<TransactionBodyView bodyView={txView.bodyView}/>) : "None"}
       </div>
       <div>
         <p>Binding Signature</p>
-        <pre>{txView.bindingSig ? txView.bindingSig.inner : "None"}</pre>
-      </div>
+        <pre>{txView.bindingSig ? txView.bindingSig.inner: "None"}</pre>
+        </div>
       <div>
         <p>Anchor</p>
         <pre>{txView.anchor ? txView.anchor.inner : "None"}</pre>

--- a/src/components/TransactionView/index.tsx
+++ b/src/components/TransactionView/index.tsx
@@ -36,17 +36,17 @@ export const TransactionView : FC<TransactionViewProps> = ({ tx }) => {
   const txView = makeTransactionView(tx);
   return (
     <div className="flex flex-col sm:items-start items-center w-full gap-y-1">
-      <div>
+      <div className="flex flex-col items-center w-full">
         <p className="text-sm font-semibold">TransactionBodyView</p>
         {txView.bodyView ? (<TransactionBodyView bodyView={txView.bodyView}/>) : "None"}
       </div>
-      <div>
-        <p>Binding Signature</p>
-        <pre>{txView.bindingSig ? txView.bindingSig.inner: "None"}</pre>
+      <div className="flex flex-col items-center w-full">
+        <p className="w-full">Binding Signature</p>
+        <pre className="w-full">{txView.bindingSig ? txView.bindingSig.inner: "None"}</pre>
         </div>
-      <div>
-        <p>Anchor</p>
-        <pre>{txView.anchor ? txView.anchor.inner : "None"}</pre>
+      <div className="flex flex-col items-center w-full">
+        <p className="w-full">Anchor</p>
+        <pre className="w-full">{txView.anchor ? txView.anchor.inner : "None"}</pre>
       </div>
     </div>
   );

--- a/src/components/ui/attribute-table.tsx
+++ b/src/components/ui/attribute-table.tsx
@@ -1,5 +1,5 @@
 "use client";
- 
+
 import {
   type ColumnDef,
   flexRender,
@@ -7,7 +7,7 @@ import {
   useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table";
- 
+
 import {
   Table,
   TableBody,
@@ -43,7 +43,7 @@ export function AttributeTable<TData, TValue>({
   });
 
   return (
-    <div className={`${className}`}>
+    <div className={`${className ?? ""}`}>
       <div className="rounded-md border">
         <Table>
           <TableHeader className="bg-slate-200">

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -1,5 +1,5 @@
 "use client";
- 
+
 import {
   type ColumnDef,
   flexRender,
@@ -7,7 +7,7 @@ import {
   useReactTable,
   type VisibilityState,
 } from "@tanstack/react-table";
- 
+
 import {
   Table,
   TableBody,
@@ -41,7 +41,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className={`${className}`}>
+    <div className={`${className ?? ""}`}>
       <div className="rounded-md border">
         <Table>
           <TableHeader className="bg-slate-200">

--- a/src/components/ui/flex.tsx
+++ b/src/components/ui/flex.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+import type { FC, ReactNode } from "react";
+
+export const FlexCol: FC<{ children?: ReactNode, className?: string }> = ({ children, className }) => {
+  return (
+    <div className={cn("flex flex-col", className ?? "")}>
+      {children}
+    </div>
+  );
+};
+
+export const FlexRow: FC<{ children?: ReactNode, className?: string }> = ({ children, className }) => {
+  return (
+    <div className={cn("flex", className ?? "")}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/ui/paginated-data-table.tsx
+++ b/src/components/ui/paginated-data-table.tsx
@@ -1,5 +1,5 @@
 "use client";
- 
+
 import {
   type ColumnDef,
   flexRender,
@@ -7,7 +7,7 @@ import {
   useReactTable,
   type PaginationState,
 } from "@tanstack/react-table";
- 
+
 import {
   Table,
   TableBody,
@@ -43,7 +43,7 @@ interface PaginatedDataTableProps<TData, TValue, Z extends z.ZodTypeAny> {
   fetcher: Fetcher<Z>,
   errorMessage: string,
 }
- 
+
 export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
   className,
   columns,
@@ -92,7 +92,7 @@ export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
   });
 
   return (
-    <div className={`${className}`}>
+    <div className={`${className ?? ""}`}>
       <div className="rounded-md border">
         <Table>
           <TableHeader className="bg-slate-200">

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -239,6 +239,8 @@ export const getFeeAmount = createGetter((fee?: Fee) => fee?.amount ? fee.amount
 
 export const getFeeAssetId = createGetter((fee?: Fee) => fee?.assetId ? fee.assetId : undefined);
 
+
+// SwapClaimView getters
 export const getSwapClaimViewBody = createGetter((swapClaimView?: SwapClaimView) =>
   swapClaimView?.swapClaimView.value?.swapClaim?.body
   ? swapClaimView.swapClaimView.value.swapClaim?.body
@@ -302,6 +304,74 @@ export const getSwapClaimNoteOutput2 = createGetter((swapClaimView?: SwapClaimVi
 export const getSwapClaimTransactionId = createGetter((swapClaimView?: SwapClaimView) =>
   swapClaimView?.swapClaimView.case === "visible"
   ? swapClaimView.swapClaimView.value.swapTx
+  : undefined,
+);
+
+// DelegatorVoteView getters
+export const getDelegatorVoteViewBody = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body
+  : undefined,
+);
+
+export const getDelegatorVoteViewAuthSig = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.authSig
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.authSig
+  : undefined,
+);
+
+export const getDelegatorVoteViewProof = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.proof
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.proof
+  : undefined,
+);
+
+export const getDelegatorVoteBodyProposal = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.proposal
+  : undefined,
+);
+
+export const getDelegatorVoteBodyStartPosition = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.startPosition
+  : undefined,
+);
+
+export const getDelegatorVoteBodyVote = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body?.vote
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.vote
+  : undefined,
+);
+
+export const getDelegatorVoteBodyValue = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body?.value
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.value
+  : undefined,
+);
+
+export const getDelegatorVoteBodyUnbondedAmount = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body?.unbondedAmount
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.unbondedAmount
+  : undefined,
+);
+
+export const getDelegatorVoteBodyNullifier = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body?.nullifier
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.nullifier
+  : undefined,
+);
+
+export const getDelegatorVoteBodyRK = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.value?.delegatorVote?.body?.rk
+  ? delegatorVoteView.delegatorVote.value.delegatorVote.body.rk
+  : undefined,
+);
+
+// DelegatorVoteView_Visible getter
+export const getDelegatorVoteViewNote = createGetter((delegatorVoteView?: DelegatorVoteView) =>
+  delegatorVoteView?.delegatorVote.case === "visible"
+  ? delegatorVoteView.delegatorVote.value.note
   : undefined,
 );
 

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -3,9 +3,10 @@ import { OutputView, OutputView_Opaque, SpendView, SpendView_Opaque } from "@buf
 import { type AddressView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { type Action, ActionView, Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { createGetter } from "./getter/create-getter";
-import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type BatchSwapOutputData } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type BatchSwapOutputData, SwapPlaintext } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import { DelegatorVoteView, DelegatorVoteView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 import { getAsset1, getAsset2 } from "@penumbra-zone/getters/src/trading-pair";
+import { Fee } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1/fee_pb";
 
 export const makeActionView = ({ action }: Action): ActionView | undefined => {
   switch (action.case) {
@@ -175,7 +176,7 @@ export const getOutputValue2FromSwapView = createGetter((swapView?: SwapView) =>
 );
 
 // SwapView_Visible getters
-export const getSwapPlainText = createGetter((swapView?: SwapView) =>
+export const getSwapPlaintext = createGetter((swapView?: SwapView) =>
   swapView?.swapView.case === "visible" ? swapView.swapView.value.swapPlaintext : undefined,
 );
 
@@ -209,6 +210,34 @@ export const getBatchSwapOutputLambda2Amount = createGetter((b?: BatchSwapOutput
 export const getBatchSwapOutputUnfilled1Amount = createGetter((b?: BatchSwapOutputData) => b?.unfilled1);
 
 export const getBatchSwapOutputUnfilled2Amount = createGetter((b?: BatchSwapOutputData) => b?.unfilled2);
+
+export const getSwapPlaintextTradingPair = createGetter((swapPlaintext?: SwapPlaintext) =>
+  swapPlaintext?.tradingPair ? swapPlaintext.tradingPair : undefined,
+);
+
+export const getSwapPlainTextAsset1 = getSwapPlaintextTradingPair.pipe(getAsset1);
+
+export const getSwapPlainTextAsset2 = getSwapPlaintextTradingPair.pipe(getAsset2);
+
+export const getSwapPlaintextDelta1 = createGetter((swapPlaintext?: SwapPlaintext) =>
+  swapPlaintext?.delta1I ? swapPlaintext.delta1I : undefined,
+);
+
+export const getSwapPlaintextDelta2 = createGetter((swapPlaintext?: SwapPlaintext) =>
+  swapPlaintext?.delta2I ? swapPlaintext.delta2I : undefined,
+);
+
+export const getSwapPlaintextFee = createGetter((swapPlaintext?: SwapPlaintext) =>
+  swapPlaintext?.claimFee ? swapPlaintext.claimFee : undefined,
+);
+
+export const getSwapPlaintextAddress = createGetter((swapPlaintext?: SwapPlaintext) =>
+  swapPlaintext?.claimAddress ? swapPlaintext.claimAddress : undefined,
+);
+
+export const getFeeAmount = createGetter((fee?: Fee) => fee?.amount ? fee.amount : undefined);
+
+export const getFeeAssetId = createGetter((fee?: Fee) => fee?.assetId ? fee.assetId : undefined);
 
 export const transactionFromBytes = (txBytes : Buffer) => {
   const txResult = TxResult.fromBinary(txBytes);

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -3,7 +3,7 @@ import { OutputView, OutputView_Opaque, SpendView, SpendView_Opaque } from "@buf
 import { type AddressView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { type Action, ActionView, Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { createGetter } from "./getter/create-getter";
-import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type BatchSwapOutputData, SwapPlaintext } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type BatchSwapOutputData, SwapPlaintext, SwapClaim } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import { DelegatorVoteView, DelegatorVoteView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 import { getAsset1, getAsset2 } from "@penumbra-zone/getters/src/trading-pair";
 import { Fee } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/fee/v1/fee_pb";
@@ -238,6 +238,72 @@ export const getSwapPlaintextAddress = createGetter((swapPlaintext?: SwapPlainte
 export const getFeeAmount = createGetter((fee?: Fee) => fee?.amount ? fee.amount : undefined);
 
 export const getFeeAssetId = createGetter((fee?: Fee) => fee?.assetId ? fee.assetId : undefined);
+
+export const getSwapClaimViewBody = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body
+  ? swapClaimView.swapClaimView.value.swapClaim?.body
+  : undefined,
+);
+
+export const getSwapClaimViewZKProof = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.proof
+  ? swapClaimView.swapClaimView.value.swapClaim.proof
+  : undefined,
+);
+
+export const getSwapClaimViewEpochDuration = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim
+  ? swapClaimView.swapClaimView.value.swapClaim.epochDuration
+  : undefined,
+);
+
+export const getSwapClaimBodyNullifier = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body?.nullifier
+  ? swapClaimView?.swapClaimView.value?.swapClaim?.body?.nullifier
+  : undefined,
+);
+
+export const getSwapClaimBodyFee = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body?.fee
+  ? swapClaimView?.swapClaimView.value?.swapClaim?.body?.fee
+  : undefined,
+);
+
+export const getSwapClaimBodyOutput1Commitment = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body?.output1Commitment
+  ? swapClaimView?.swapClaimView.value?.swapClaim?.body?.output1Commitment
+  : undefined,
+);
+
+export const getSwapClaimBodyOutput2Commitment = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body?.output2Commitment
+  ? swapClaimView?.swapClaimView.value?.swapClaim?.body?.output2Commitment
+  : undefined,
+);
+
+export const getSwapClaimBodyBatchOutputData = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.value?.swapClaim?.body?.outputData
+  ? swapClaimView?.swapClaimView.value?.swapClaim?.body?.outputData
+  : undefined,
+);
+
+export const getSwapClaimNoteOutput1 = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.case === "visible"
+  ? swapClaimView.swapClaimView.value.output1
+  : undefined,
+);
+
+export const getSwapClaimNoteOutput2 = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.case === "visible"
+  ? swapClaimView.swapClaimView.value.output2
+  : undefined,
+);
+
+export const getSwapClaimTransactionId = createGetter((swapClaimView?: SwapClaimView) =>
+  swapClaimView?.swapClaimView.case === "visible"
+  ? swapClaimView.swapClaimView.value.swapTx
+  : undefined,
+);
 
 export const transactionFromBytes = (txBytes : Buffer) => {
   const txResult = TxResult.fromBinary(txBytes);

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -3,7 +3,7 @@ import { OutputView, OutputView_Opaque, SpendView, SpendView_Opaque } from "@buf
 import { type AddressView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { type Action, ActionView, Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { createGetter } from "./getter/create-getter";
-import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, SwapBody, Swap } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import { DelegatorVoteView, DelegatorVoteView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 
 export const makeActionView = ({ action }: Action): ActionView | undefined => {
@@ -78,7 +78,7 @@ export const makeActionView = ({ action }: Action): ActionView | undefined => {
           }),
         },
       });
-    // TODO: None of these actions have *View equivalents. Is exhausitively constructing an ActionView from them OK?
+    // TODO: None of these actions have *View equivalents (and, transatively, Opaque/Decoded variants). Is exhausitively constructing an ActionView from them OK?
     case "validatorDefinition":
     case "ibcRelayAction":
     case "proposalSubmit":
@@ -129,6 +129,25 @@ export const getOutputNote = createGetter((outputView?: OutputView) =>
 
 export const getOutputKey = createGetter((outputView?: OutputView) =>
   outputView?.outputView.case === "visible" ? outputView.outputView.value.payloadKey : undefined,
+);
+
+export const getSwap = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.value?.swap ? swapView.swapView.value.swap : undefined,
+);
+
+export const getSwapMetadata = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" ? swapView.swapView.value.asset1Metadata : undefined,
+);
+
+export const getSwapBodyAmounts = createGetter((swapBody?: SwapBody) =>
+  swapBody?.delta1I && swapBody.delta2I ? { delta1I: swapBody.delta1I, delta2I: swapBody.delta2I }: undefined,
+);
+
+export const getSwapBodyPayload = createGetter((swapBody?: SwapBody) =>
+  swapBody?.payload ? swapBody.payload : undefined,
+);
+export const getSwapBodyFeeCommitment = createGetter((swapBody?: SwapBody) =>
+  swapBody?.feeCommitment ? swapBody.feeCommitment : undefined,
 );
 
 export const transactionFromBytes = (txBytes : Buffer) => {

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -3,8 +3,9 @@ import { OutputView, OutputView_Opaque, SpendView, SpendView_Opaque } from "@buf
 import { type AddressView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { type Action, ActionView, Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { createGetter } from "./getter/create-getter";
-import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type SwapView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type BatchSwapOutputData } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import { DelegatorVoteView, DelegatorVoteView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
+import { getAsset1, getAsset2 } from "@penumbra-zone/getters/src/trading-pair";
 
 export const makeActionView = ({ action }: Action): ActionView | undefined => {
   switch (action.case) {
@@ -172,6 +173,42 @@ export const getOutputValue1FromSwapView = createGetter((swapView?: SwapView) =>
 export const getOutputValue2FromSwapView = createGetter((swapView?: SwapView) =>
   swapView?.swapView.case === "opaque" ? swapView.swapView.value.output2Value : undefined,
 );
+
+// SwapView_Visible getters
+export const getSwapPlainText = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" ? swapView.swapView.value.swapPlaintext : undefined,
+);
+
+export const getSwapTransactionId = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" ? swapView.swapView.value.claimTx : undefined,
+);
+
+export const getSwapNoteViewOutput1 = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" ? swapView.swapView.value.output1 : undefined,
+);
+
+export const getSwapNoteViewOutput2 = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" ? swapView.swapView.value.output2 : undefined,
+);
+
+// all BatchSwapOutputData getters
+export const getBatchSwapOutputTradingPair = createGetter((b?: BatchSwapOutputData) => b?.tradingPair);
+
+export const getBatchSwapOutputAsset1 = getBatchSwapOutputTradingPair.pipe(getAsset1);
+
+export const getBatchSwapOutputAsset2 = getBatchSwapOutputTradingPair.pipe(getAsset2);
+
+export const getBatchSwapOutputDelta1Amount = createGetter((b?: BatchSwapOutputData) => b?.delta1);
+
+export const getBatchSwapOutputDelta2Amount = createGetter((b?: BatchSwapOutputData) => b?.delta2);
+
+export const getBatchSwapOutputLambda1Amount = createGetter((b?: BatchSwapOutputData) => b?.lambda1);
+
+export const getBatchSwapOutputLambda2Amount = createGetter((b?: BatchSwapOutputData) => b?.lambda2);
+
+export const getBatchSwapOutputUnfilled1Amount = createGetter((b?: BatchSwapOutputData) => b?.unfilled1);
+
+export const getBatchSwapOutputUnfilled2Amount = createGetter((b?: BatchSwapOutputData) => b?.unfilled2);
 
 export const transactionFromBytes = (txBytes : Buffer) => {
   const txResult = TxResult.fromBinary(txBytes);

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -3,7 +3,7 @@ import { OutputView, OutputView_Opaque, SpendView, SpendView_Opaque } from "@buf
 import { type AddressView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/keys/v1/keys_pb";
 import { type Action, ActionView, Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { createGetter } from "./getter/create-getter";
-import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, SwapBody, Swap } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
+import { SwapView, SwapView_Opaque, SwapClaimView, SwapClaimView_Opaque, type SwapBody, type SwapView_Visible } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/dex/v1/dex_pb";
 import { DelegatorVoteView, DelegatorVoteView_Opaque } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/component/governance/v1/governance_pb";
 
 export const makeActionView = ({ action }: Action): ActionView | undefined => {
@@ -135,8 +135,16 @@ export const getSwap = createGetter((swapView?: SwapView) =>
   swapView?.swapView.value?.swap ? swapView.swapView.value.swap : undefined,
 );
 
-export const getSwapMetadata = createGetter((swapView?: SwapView) =>
-  swapView?.swapView.case === "visible" ? swapView.swapView.value.asset1Metadata : undefined,
+export const getSwapMetadata1 = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" || swapView?.swapView.case === "opaque"
+  ? swapView.swapView.value.asset1Metadata
+  : undefined,
+);
+
+export const getSwapMetadata2 = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" || swapView?.swapView.case === "opaque"
+  ? swapView.swapView.value.asset2Metadata
+  : undefined,
 );
 
 export const getSwapBodyAmounts = createGetter((swapBody?: SwapBody) =>
@@ -146,8 +154,15 @@ export const getSwapBodyAmounts = createGetter((swapBody?: SwapBody) =>
 export const getSwapBodyPayload = createGetter((swapBody?: SwapBody) =>
   swapBody?.payload ? swapBody.payload : undefined,
 );
+
 export const getSwapBodyFeeCommitment = createGetter((swapBody?: SwapBody) =>
   swapBody?.feeCommitment ? swapBody.feeCommitment : undefined,
+);
+
+export const getBatchSwapOutputData = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "visible" || swapView?.swapView.case === "opaque"
+  ? swapView.swapView.value.batchSwapOutputData
+  : undefined,
 );
 
 export const transactionFromBytes = (txBytes : Buffer) => {

--- a/src/lib/protobuf.ts
+++ b/src/lib/protobuf.ts
@@ -165,6 +165,14 @@ export const getBatchSwapOutputData = createGetter((swapView?: SwapView) =>
   : undefined,
 );
 
+export const getOutputValue1FromSwapView = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "opaque" ? swapView.swapView.value.output1Value : undefined,
+);
+
+export const getOutputValue2FromSwapView = createGetter((swapView?: SwapView) =>
+  swapView?.swapView.case === "opaque" ? swapView.swapView.value.output2Value : undefined,
+);
+
 export const transactionFromBytes = (txBytes : Buffer) => {
   const txResult = TxResult.fromBinary(txBytes);
   return Transaction.fromBinary(txResult.tx);


### PR DESCRIPTION
Part of #81 work

This PR finishes a first pass at the ActionViews with `Visible` and `Opaque` variants along with a dozen or so components for the message types that make up their definitions and ~3 dozen getters for accessing these values.

While still rough, the skeleton for `TransactionView`s is more coherent now and opens up the path for other issues to be addressed.