### PR TITLE
initial `React.Suspense` support in client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@next/eslint-plugin-next": "^14.2.3",
         "@pgtyped/cli": "^2.3.0",
         "@stylistic/eslint-plugin": "^2.1.0",
+        "@tanstack/react-query-devtools": "^5.51.1",
         "@types/eslint": "^8.56.10",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -2223,9 +2224,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.49.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.49.1.tgz",
-      "integrity": "sha512-JnC9ndmD1KKS01Rt/ovRUB1tmwO7zkyXAyIxN9mznuJrcNtOrkmOnQqdJF2ib9oHzc2VxHomnEG7xyfo54Npkw==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.51.1.tgz",
+      "integrity": "sha512-fJBMQMpo8/KSsWW5ratJR5+IFr7YNJ3K2kfP9l5XObYHsgfVy1w3FJUWU4FT2fj7+JMaEg33zOcNDBo0LMwHnw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.51.1.tgz",
+      "integrity": "sha512-rehG0WmL3EXER6MAI2uHQia/n0b5c3ZROohpYm7u3G7yg4q+HsfQy6nuAo6uy40NzHUe3FmnfWCZQ0Vb/3lE6g==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2233,12 +2245,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.49.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.49.2.tgz",
-      "integrity": "sha512-6rfwXDK9BvmHISbNFuGd+wY3P44lyW7lWiA9vIFGT/T0P9aHD1VkjTvcM4SDAIbAQ9ygEZZoLt7dlU1o3NjMVA==",
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.51.1.tgz",
+      "integrity": "sha512-s47HKFnQ4HOJAHoIiXcpna/roMMPZJPy6fJ6p4ZNVn8+/onlLBEDd1+xc8OnDuwgvecqkZD7Z2mnSRbcWefrKw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.49.1"
+        "@tanstack/query-core": "5.51.1"
       },
       "funding": {
         "type": "github",
@@ -2246,6 +2258,24 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.51.1.tgz",
+      "integrity": "sha512-bRShIVKGpUOHpwziGKT8Aq1Ty0lIlGmNI7E0KbGYtmyOaImErpdElTdxfES1bRaI7i/j+mf2hLy+E6q7SrCwPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.51.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.51.1",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
-        "@tanstack/react-query": "^5.0.5",
+        "@tanstack/react-query": "^5.49.2",
         "@tanstack/react-table": "^8.10.6",
         "@types/pg": "^8.11.6",
         "axios": "^1.5.1",
@@ -2223,9 +2223,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.40.0.tgz",
-      "integrity": "sha512-eD8K8jsOIq0Z5u/QbvOmfvKKE/XC39jA7yv4hgpl/1SRiU+J8QCIwgM/mEHuunQsL87dcvnHqSVLmf9pD4CiaA==",
+      "version": "5.49.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.49.1.tgz",
+      "integrity": "sha512-JnC9ndmD1KKS01Rt/ovRUB1tmwO7zkyXAyIxN9mznuJrcNtOrkmOnQqdJF2ib9oHzc2VxHomnEG7xyfo54Npkw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2233,12 +2233,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.40.0.tgz",
-      "integrity": "sha512-iv/W0Axc4aXhFzkrByToE1JQqayxTPNotCoSCnarR/A1vDIHaoKpg7FTIfP3Ev2mbKn1yrxq0ZKYUdLEJxs6Tg==",
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.49.2.tgz",
+      "integrity": "sha512-6rfwXDK9BvmHISbNFuGd+wY3P44lyW7lWiA9vIFGT/T0P9aHD1VkjTvcM4SDAIbAQ9ygEZZoLt7dlU1o3NjMVA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.40.0"
+        "@tanstack/query-core": "5.49.1"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@next/eslint-plugin-next": "^14.2.3",
     "@pgtyped/cli": "^2.3.0",
     "@stylistic/eslint-plugin": "^2.1.0",
+    "@tanstack/react-query-devtools": "^5.51.1",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
-    "@tanstack/react-query": "^5.0.5",
+    "@tanstack/react-query": "^5.49.2",
     "@tanstack/react-table": "^8.10.6",
     "@types/pg": "^8.11.6",
     "axios": "^1.5.1",

--- a/src/app/block/[ht]/page.tsx
+++ b/src/app/block/[ht]/page.tsx
@@ -15,7 +15,7 @@ interface PageProps {
 const Page : FC<PageProps> = ({ params }) => {
   const { ht } = params;
 
-  const { data: blockData , isError } = useQuery({
+  const { data: blockData , isError, isPending, isSuccess } = useQuery({
     queryFn: async () => {
       console.log(`Fetching: GET /api/block?q=${ht}`);
       const { data } = await axios.get(`/api/block?q=${ht}`);
@@ -34,32 +34,34 @@ const Page : FC<PageProps> = ({ params }) => {
     },
   });
 
+  if (isPending) {
+    return (
+      <div className="bg-primary rounded-sm shadow-md">
+        <h1 className="text-lg font-semibold">Loading...</h1>
+      </div>
+    );
+  }
+
   if (isError) {
     return (
-      <div className="py-5 flex justify-center">
+      <div className="bg-primary py-5 flex justify-center">
         <h1 className="text-4xl font-semibold">No results found.</h1>
       </div>
     );
   }
 
-  // TODO: Replace with data table component views once those are fleshed out.
-  return (
-    <div className="bg-primary rounded-sm shadow-md">
-      {blockData ? (
+  if (isSuccess) {
+    return (
+      <div className="bg-primary rounded-sm shadow-md">
         <div className="flex flex-col gap-5 pt-5 items-center">
           <h1 className="sm:text-2xl text-lg font-bold">Block Summary</h1>
           <div className="sm:w-11/12 w-full">
             <Block height={ht} {...blockData}/>
           </div>
         </div>
-      ) : (
-        <div>
-          <p className="font-semibold">No block event</p>
-          <p>To be frank... You shouldn&apos;t be able to see this.</p>
-        </div>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
 };
 
 export default Page;

--- a/src/app/block/[ht]/page.tsx
+++ b/src/app/block/[ht]/page.tsx
@@ -1,10 +1,7 @@
-"use client";
-
 import { type FC } from "react";
-import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
-import { BlockData } from "@/lib/validators/search";
-import Block from "@/components/Block";
+import { Block } from "@/components/Block";
+import { getBlock } from "@/components/Block/getBlock";
+import { getQueryClient } from "@/lib/utils";
 
 interface PageProps {
   params: {
@@ -15,53 +12,30 @@ interface PageProps {
 const Page : FC<PageProps> = ({ params }) => {
   const { ht } = params;
 
-  const { data: blockData , isError, isPending, isSuccess } = useQuery({
-    queryFn: async () => {
-      console.log(`Fetching: GET /api/block?q=${ht}`);
-      const { data } = await axios.get(`/api/block?q=${ht}`);
-      console.log("Fetching result:", data);
-      const result = BlockData.safeParse(data);
-      if (result.success) {
-        return result.data;
-      } else {
-        throw new Error(result.error.message);
-      }
-    },
+  const queryClient = getQueryClient();
+
+  const endpoint = "/api/block/";
+  const queryName = "htQuery";
+  const errorMessage = "Failed to query block with provided height, please check height or try a different query";
+
+  queryClient.prefetchQuery({
+    queryFn: () => getBlock({ endpoint, ht }),
     queryKey: ["htQuery", ht],
-    retry: false,
     meta: {
-      errorMessage: "Failed to find block event with provided height. Please check height or try a different query.",
+      errorMessage,
     },
   });
 
-  if (isPending) {
-    return (
-      <div className="bg-primary rounded-sm shadow-md">
-        <h1 className="text-lg font-semibold">Loading...</h1>
-      </div>
-    );
-  }
-
-  if (isError) {
-    return (
-      <div className="bg-primary py-5 flex justify-center">
-        <h1 className="text-4xl font-semibold">No results found.</h1>
-      </div>
-    );
-  }
-
-  if (isSuccess) {
-    return (
-      <div className="bg-primary rounded-sm shadow-md">
-        <div className="flex flex-col gap-5 pt-5 items-center">
-          <h1 className="sm:text-2xl text-lg font-bold">Block Summary</h1>
-          <div className="sm:w-11/12 w-full">
-            <Block height={ht} {...blockData}/>
-          </div>
+  return (
+    <div className="bg-primary rounded-sm shadow-md">
+      <div className="flex flex-col gap-5 pt-5 items-center">
+        <h1 className="sm:text-2xl text-lg font-bold">Block Summary</h1>
+        <div className="sm:w-11/12 w-full">
+          <Block {...{endpoint, queryName, ht }}/>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,11 +1,12 @@
 import { BlocksTable } from "@/components/BlocksTable";
 import getBlocks from "@/components/BlocksTable/getBlocks";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/utils";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 
 export const dynamic = "force-dynamic";
 
 const Page = () => {
-  const queryClient = new QueryClient();
+  const queryClient = getQueryClient();
 
   const defaultQueryOptions = {
     pageIndex: 0,

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,4 +1,4 @@
-import BlocksTable from "@/components/BlocksTable";
+import { BlocksTable } from "@/components/BlocksTable";
 import getBlocks from "@/components/BlocksTable/getBlocks";
 import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 
@@ -11,13 +11,14 @@ const Page = () => {
     pageIndex: 0,
     pageSize: 10,
   };
+
   const queryName = "BlocksTable";
   const endpoint = "/api/blocks";
   const errorMessage = "Failed to query data while trying to generate blocks table, please try reloading the page.";
 
   queryClient.prefetchQuery({
     queryFn: () => getBlocks({ endpoint, pageIndex: 0}),
-    queryKey: [queryName, defaultQueryOptions],
+    queryKey: [queryName, defaultQueryOptions.pageIndex],
     meta: {
       errorMessage,
     },

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -1,13 +1,39 @@
 import BlocksTable from "@/components/BlocksTable";
+import getBlocks from "@/components/BlocksTable/getBlocks";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 
 export const dynamic = "force-dynamic";
 
 const Page = () => {
+  const queryClient = new QueryClient();
+
+  const defaultQueryOptions = {
+    pageIndex: 0,
+    pageSize: 10,
+  };
+  const queryName = "BlocksTable";
+  const endpoint = "/api/blocks";
+  const errorMessage = "Failed to query data while trying to generate blocks table, please try reloading the page.";
+
+  queryClient.prefetchQuery({
+    queryFn: () => getBlocks({ endpoint, pageIndex: 0}),
+    queryKey: [queryName, defaultQueryOptions],
+    meta: {
+      errorMessage,
+    },
+  });
 
   return (
     <div className="bg-primary flex flex-col gap-5 pt-5">
       <h1 className="sm:text-2xl font-bold self-center">Recent Blocks</h1>
-      <BlocksTable className="self-center sm:w-2/3 w-full"/>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <BlocksTable
+          className="self-center sm:w-2/3 w-full"
+          queryName={queryName}
+          defaultQueryOptions={defaultQueryOptions}
+          endpoint={endpoint}
+          errorMessage={errorMessage}/>
+      </HydrationBoundary>
     </div>
   );
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
  
-    --muted: 0 0% 96% / 1.0;
+    --muted: 0 0% 96% / 0.9;
     --muted-foreground: 0 0% 45% / 1.0;
  
     --accent: 210 40% 96.1%;
@@ -60,7 +60,7 @@
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
  
-    --muted: 270 34% 17%;
+    --muted: 270 34% 17% / 0.9;
     --muted-foreground: 0 0% 45% / 1.0;
  
     --accent: 217.2 32.6% 17.5%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import "@/lib/patch-toJSON-BigInt";
 import Navbar from "@/components/Navbar";
 import Providers from "@/components/Providers";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { CodeIcon } from "lucide-react";
 import Link from "next/link";
 
@@ -41,6 +42,7 @@ export default function RootLayout({
               </Link>
             </div>
           </div>
+          <ReactQueryDevtools initialIsOpen={false} />
         </Providers>
       </body>
     </html>

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-5 w-full h-full">
+      <Skeleton className="min-w-[300px] sm:min-w-[500px] h-[150px] rounded-lg"/>
+      <Skeleton className="w-full min-h-[350px] rounded-lg"/>
+      <Skeleton className="min-w-[200px] min-h-[100px] rounded-lg"/>
+    </div>
+  );
+}

--- a/src/app/transaction/[hash]/page.tsx
+++ b/src/app/transaction/[hash]/page.tsx
@@ -1,10 +1,9 @@
-"use client";
-
+// "use client";
 import { type FC } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { TransactionResult } from "@/lib/validators/search";
-import axios from "axios";
-import Transaction from "@/components/Transaction";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { Transaction } from "@/components/Transaction";
+import getTransaction from "@/components/Transaction/getTransaction";
+import { getQueryClient } from "@/lib/utils";
 
 interface PageProps {
   params: {
@@ -12,51 +11,31 @@ interface PageProps {
   }
 }
 
-// TODO: this entire page could probably be rendered statically on the server via layout.ts & some minor optimization via tanstack query context.
 const Page : FC<PageProps> = ({ params }) => {
   const { hash } = params;
 
-  const { data: txData , isError } = useQuery({
-    queryFn: async () => {
-      console.log(`Fetching: GET /api/transaction?q=${hash}`);
-      const { data } = await axios.get(`/api/transaction?q=${hash}`);
-      console.log("Fetched result:", data);
-      const result = TransactionResult.safeParse(data);
+  const queryClient = getQueryClient();
 
-      if (result.success) {
-        return result.data;
-      } else {
-        throw new Error(result.error.message);
-      }
-    },
-    queryKey: ["txQuery", hash],
-    retry: false,
+  const endpoint = "/api/transaction/";
+  const queryName = "txQuery";
+  const errorMessage = "Failed to query transaction, please try reloading the page.";
+
+  queryClient.prefetchQuery({
+    queryKey: [queryName, hash],
+    queryFn: () => getTransaction({ endpoint, hash }),
     meta: {
-      errorMessage: "Failed to find transaction event with provided hash. Please check hash or try a different query.",
+      errorMessage,
     },
   });
 
-  if (isError) {
-    return (
-      <div className="py-5 flex justify-center">
-        <h1 className="text-4xl font-semibold">No results found.</h1>
-      </div>
-    );
-  }
-
-  // TODO: Replace with data table component views once those are fleshed out.
-  // TODO: add Suspense
   return (
-    <div className="bg-primary rounded-sm shadow-md">
-      {txData ? (
-        <div className="flex flex-col items-center gap-5 pt-5">
-          <h1 className="sm:text-2xl text-lg font-bold">Transaction Event Summary</h1>
-          <div className="sm:w-11/12 w-full">
-            <Transaction txData={txData} />
-          </div>
+    <div className="bg-primary flex flex-col gap-5 pt-5 items-center ">
+      <h1 className="font-medium">Transaction Summary</h1>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <div className="sm:w-11/12 w-full">
+          <Transaction {...{endpoint, queryName, hash}}/>
         </div>
-        ) : <p>No results</p>
-      }
+      </HydrationBoundary>
     </div>
   );
 };

--- a/src/app/transaction/[hash]/page.tsx
+++ b/src/app/transaction/[hash]/page.tsx
@@ -1,8 +1,7 @@
-// "use client";
 import { type FC } from "react";
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import { Transaction } from "@/components/Transaction";
-import getTransaction from "@/components/Transaction/getTransaction";
+import { getTransaction } from "@/components/Transaction/getTransaction";
 import { getQueryClient } from "@/lib/utils";
 
 interface PageProps {

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,12 +1,13 @@
 import { TransactionsTable } from "@/components/TransactionsTable";
 import getTransactions from "@/components/TransactionsTable/getTransactions";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { getQueryClient } from "@/lib/utils";
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 
 // TODO: do we want this anymore? what is the story of caching between the client and events.
 export const dynamic = "force-dynamic";
 
 const Page = () => {
-  const queryClient = new QueryClient();
+  const queryClient = getQueryClient();
 
   const defaultQueryOptions = {
     pageIndex: 0,

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -19,7 +19,7 @@ const Page = () => {
 
   queryClient.prefetchQuery({
     queryFn: () => getTransactions({ endpoint, pageIndex: 0}),
-    queryKey: [queryName, defaultQueryOptions],
+    queryKey: [queryName, defaultQueryOptions.pageIndex],
     meta: {
       errorMessage,
     },

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,12 +1,41 @@
-import TransactionsTable from "@/components/TransactionsTable";
+import { TransactionsTable } from "@/components/TransactionsTable";
+import getTransactions from "@/components/TransactionsTable/getTransactions";
+import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
 
+// TODO: do we want this anymore? what is the story of caching between the client and events.
 export const dynamic = "force-dynamic";
 
-const Page = async () => {
+const Page = () => {
+  const queryClient = new QueryClient();
+
+  const defaultQueryOptions = {
+    pageIndex: 0,
+    pageSize: 10,
+  };
+
+  const endpoint = "/api/transactions";
+  const queryName = "TransactionsTable";
+  const errorMessage = "Failed to query data while trying to generate event table, please try reloading the page.";
+
+  queryClient.prefetchQuery({
+    queryFn: () => getTransactions({ endpoint, pageIndex: 0}),
+    queryKey: [queryName, defaultQueryOptions],
+    meta: {
+      errorMessage,
+    },
+  });
+
   return (
     <div className="bg-primary flex flex-col gap-5 pt-5 items-center">
       <h1 className="sm:text-2xl font-bold">Recent Transactions</h1>
-      <TransactionsTable className="sm:w-11/12 w-full"/>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <TransactionsTable
+          className="sm:w-11/12 w-full"
+          queryName={queryName}
+          defaultQueryOptions={defaultQueryOptions}
+          endpoint={endpoint}
+          errorMessage={errorMessage}/>
+      </HydrationBoundary>
     </div>
   );
 };

--- a/src/components/Block/getBlock.ts
+++ b/src/components/Block/getBlock.ts
@@ -1,0 +1,14 @@
+import { BlockData } from "@/lib/validators/search";
+
+export async function getBlock({ endpoint, ht } : { endpoint: string, ht: string}) {
+  console.log(`Fetching: GET ${endpoint}?q=${ht}`);
+  const res = await fetch(`http://localhost:3000${endpoint}?q=${ht}`, { method: "GET" });
+  const json = await res.json();
+  console.log("Fetched Result:", json);
+  const result = BlockData.safeParse(json);
+  if (result.success) {
+    return result.data;
+  } else {
+    throw new Error(result.error.message);
+  }
+}

--- a/src/components/Block/index.tsx
+++ b/src/components/Block/index.tsx
@@ -1,21 +1,32 @@
-import { type BlockDataPayload } from "@/lib/validators/search";
+"use client";
+
 import Link from "next/link";
 import { type FC } from "react";
 import ABCIEventsTable from "../ABCIEventsTable";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getBlock } from "./getBlock";
 
-
-interface BlockProps extends BlockDataPayload {
-  height: string
+interface BlockProps {
+  endpoint: string,
+  queryName: string,
+  ht: string,
 }
 
-// TODO: Similar to TransactionEvent, it looks increasingly likely that tanstack/table will actually work here so pulling out different DataTable representations will need to happen.
-const Block : FC<BlockProps> = ({ height, created_at, tx_hashes, events }) => {
+export const Block : FC<BlockProps> = ({ endpoint, queryName, ht }) => {
+
+  const { data } = useSuspenseQuery({
+    queryKey: [queryName, ht],
+    queryFn: () => getBlock({ endpoint, ht }),
+  });
+
+  const { created_at, tx_hashes, events } = data;
+
   return (
     <div>
       <div className="flex flex-wrap justify-between sm:p-5 p-2 sm:gap-y-10 gap-y-5 w-full">
         <div className="flex flex-wrap justify-start w-full">
           <p className="sm:w-1/6 w-full font-semibold">Block Height</p>
-          <pre className="sm:w-0 w-full">{height}</pre>
+          <pre className="sm:w-0 w-full">{ht}</pre>
         </div>
         <div className="flex flex-wrap justify-start w-full">
           <p className="w-1/6 font-semibold">Timestamp</p>
@@ -40,5 +51,3 @@ const Block : FC<BlockProps> = ({ height, created_at, tx_hashes, events }) => {
     </div>
   );
 };
-
-export default Block;

--- a/src/components/BlocksTable/getBlocks.ts
+++ b/src/components/BlocksTable/getBlocks.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { BlocksTableQuery } from "@/lib/validators/table";
 
 export default async function getBlocks ({ endpoint, pageIndex } : ({ endpoint: string, pageIndex: number })) {

--- a/src/components/BlocksTable/index.tsx
+++ b/src/components/BlocksTable/index.tsx
@@ -1,47 +1,63 @@
-"use server";
+"use client";
 
 import { columns } from "./columns";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { PaginatedDataTable } from "../ui/paginated-data-table";
+import { PaginationState, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import getBlocks from "./getBlocks";
+import { cn } from "@/lib/utils";
 
-export interface BlocksTableRow {
-  height: number,
-  createdAt: Date,
-  // TODO: It would be nice to associate all events with a given row. Need to get testnet setup again and pull in example data for building this out.
-  // events: any[],
-};
+export interface QueryOptions {
+  pageIndex: number,
+  pageSize: number,
+}
 
-const BlocksTable = async ({ className } : { className: string }) => {
-  const queryClient = new QueryClient();
+interface PaginatedDataTableProps {
+  className?: string,
+  queryName: string,
+  defaultQueryOptions: QueryOptions,
+  endpoint: string,
+  errorMessage: string,
+}
 
-  const defaultQueryOptions = {
-    pageIndex: 0,
-    pageSize: 10,
-  };
-  const queryName = "BlocksTable";
-  const endpoint = "/api/blocks";
-  const errorMessage = "Failed to query data while trying to generate blocks table, please try reloading the page.";
 
-  await queryClient.prefetchQuery({
-    queryFn: async () => await getBlocks({ endpoint, pageIndex: 0}),
-    queryKey: [queryName, defaultQueryOptions],
+export function BlocksTable ({
+  className,
+  queryName,
+  defaultQueryOptions,
+  endpoint,
+  errorMessage,
+} : PaginatedDataTableProps) {
+
+  const [pagination, setPagination] = useState<PaginationState>({...defaultQueryOptions});
+
+  const { data } = useSuspenseQuery({
+    queryKey: [queryName, pagination],
+    queryFn: () => getBlocks({ endpoint, pageIndex: pagination.pageIndex }),
     meta: {
       errorMessage,
     },
   });
 
+  const { pages: pageCount, results: tableData } = data ?? { pages: 0, results: []};
+
+  const table = useReactTable({
+    data: tableData,
+    columns,
+    pageCount,
+    state: {
+      pagination,
+    },
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
+
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <PaginatedDataTable
-        className={className}
-        queryName={queryName}
-        defaultQueryOptions={defaultQueryOptions}
-        columns={columns}
-        fetcher={getBlocks}
-        endpoint={endpoint}
-        errorMessage={errorMessage}/>
-    </HydrationBoundary>
+    <div className={cn("", className)}>
+      <PaginatedDataTable table={table} columns={columns}/>
+    </div>
   );
 };
 

--- a/src/components/BlocksTable/index.tsx
+++ b/src/components/BlocksTable/index.tsx
@@ -33,7 +33,7 @@ export function BlocksTable ({
   const [pagination, setPagination] = useState<PaginationState>({...defaultQueryOptions});
 
   const { data } = useSuspenseQuery({
-    queryKey: [queryName, pagination],
+    queryKey: [queryName, pagination.pageIndex],
     queryFn: () => getBlocks({ endpoint, pageIndex: pagination.pageIndex }),
     meta: {
       errorMessage,
@@ -60,5 +60,3 @@ export function BlocksTable ({
     </div>
   );
 };
-
-export default BlocksTable;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -10,7 +10,7 @@ import { ThemeToggleButton } from "../ThemeToggleButton";
 const Navbar : FC = () => {
   return (
   <div className="flex items-center justify-between py-5 max-w-[1200px] ml-auto mr-auto">
-    <h1 className="font-bold text-lg py-5"><Link href="/">Penumbra Explorer</Link></h1>
+    <h1 className="font-bold text-lg py-5"><Link href="/">Cuiloa Block Explorer</Link></h1>
     <div className="w-5/6 sm:max-w-lg">
       <SearchBar/>
     </div>

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -26,7 +26,6 @@ const makeQueryClient = () => {
       queries: {
         // Direct suggestion by tanstack, to prevent over-eager refetching from the client.
         staleTime: 60 * 1000,
-        refetchOnWindowFocus: false,
       },
       dehydrate: {
         // only successful and pending Queries are included per defaults

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { QueryCache, QueryClient, QueryClientProvider, isServer  } from "@tanstack/react-query";
+import { QueryCache, QueryClient, QueryClientProvider, defaultShouldDehydrateQuery, isServer  } from "@tanstack/react-query";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { TransportProvider } from "@connectrpc/connect-query";
 import { Toaster } from "../ui/toaster";
@@ -26,6 +26,13 @@ const makeQueryClient = () => {
       queries: {
         // Direct suggestion by tanstack, to prevent over-eager refetching from the client.
         staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+      },
+      dehydrate: {
+        // only successful and pending Queries are included per defaults
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
       },
     },
     queryCache: new QueryCache({

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import React, { useState } from "react";
-import { QueryCache, QueryClient, QueryClientProvider, defaultShouldDehydrateQuery, isServer  } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { TransportProvider } from "@connectrpc/connect-query";
 import { Toaster } from "../ui/toaster";
-import { toast } from "../ui/use-toast";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ThemeProviderProps } from "next-themes/dist/types";
+import { getQueryClient } from "@/lib/utils";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
@@ -16,71 +16,6 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 const penumbraTransport = createGrpcWebTransport({
   baseUrl: "https://grpc.testnet.penumbra.zone",
 });
-
-let browserQueryClient: QueryClient | undefined = undefined;
-
-const makeQueryClient = () => {
-  // const { toast } = useToast();
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        // Direct suggestion by tanstack, to prevent over-eager refetching from the client.
-        staleTime: 60 * 1000,
-      },
-      dehydrate: {
-        // only successful and pending Queries are included per defaults
-        shouldDehydrateQuery: (query) =>
-          defaultShouldDehydrateQuery(query) ||
-          query.state.status === "pending",
-      },
-    },
-    queryCache: new QueryCache({
-      onError: (error, query) => {
-        // TODO: Overall model is fine but need to change how meta is used.
-        // Idea: Add a `errorTitle` field instead that can be used in place of "Error" below. This gives a top level, succinct explanation.
-        //       `description` becomes whatever value we store inside our error value. This is what needs to be refactored to make all queries play nicely.
-        //       This allows each error to clearly signal its nature while also giving detail where appropriate. The issue of that detail is delegated to the useQuery callsite
-        //       and any component/route that throws errors.
-        // There may be a more elegant way of expressing this but the general typing of onError's `error` and `query` arguments requires some amount of refinement for safety.
-        // https://tanstack.com/query/latest/docs/react/reference/QueryCache
-        let errorMessage = "";
-        const meta = query?.meta ?? undefined ;
-        if (meta) {
-          // Precondition for this type cast: meta is of type Record<string, unknown> where any query with a meta object containing the property `errorMessage` has a value of type string.
-          errorMessage = meta?.errorMessage as string ?? "";
-        }
-        if (errorMessage !== "") {
-          toast({
-            variant: "destructive",
-            title: "Error",
-            description: `${errorMessage}`,
-          });
-        } else {
-          // TODO: Realistically, this will not be a useful error and should be improved further.
-          toast({
-            variant: "destructive",
-            title: "Error",
-            description: `${error.message}`,
-          });
-        }
-      },
-    }),
-  });
-};
-
-const getQueryClient = () => {
-  if (isServer) {
-    // Server: always make a new query client
-    return makeQueryClient();
-  } else {
-    // Browser: make a new query client if we don't already have one
-    // This is very important, so we don't re-make a new client if React
-    // suspends during the initial render. This may not be needed if we
-    // have a suspense boundary BELOW the creation of the query client
-    if (!browserQueryClient) browserQueryClient = makeQueryClient();
-    return browserQueryClient;
-  }
-};
 
 
 const Providers = ({ children } : { children: React.ReactNode }) => {

--- a/src/components/Transaction/getTransaction.ts
+++ b/src/components/Transaction/getTransaction.ts
@@ -1,0 +1,14 @@
+import { TransactionData } from "@/lib/validators/search";
+
+export default async function getTransaction({ endpoint, hash } : { endpoint: string, hash: string}) {
+  console.log(`Fetching: POST ${endpoint}?q=${hash}`);
+  const res = await fetch(`http://localhost:3000${endpoint}?q=${hash}`, { method: "GET" });
+  const json = await res.json();
+  console.log("Fetched Result:", json);
+  const result = TransactionData.safeParse(json);
+  if (result.success) {
+    return result.data;
+  } else {
+    throw new Error(result.error.message);
+  }
+}

--- a/src/components/Transaction/getTransaction.ts
+++ b/src/components/Transaction/getTransaction.ts
@@ -1,7 +1,7 @@
 import { TransactionData } from "@/lib/validators/search";
 
-export default async function getTransaction({ endpoint, hash } : { endpoint: string, hash: string}) {
-  console.log(`Fetching: POST ${endpoint}?q=${hash}`);
+export async function getTransaction({ endpoint, hash } : { endpoint: string, hash: string}) {
+  console.log(`Fetching: GET ${endpoint}?q=${hash}`);
   const res = await fetch(`http://localhost:3000${endpoint}?q=${hash}`, { method: "GET" });
   const json = await res.json();
   console.log("Fetched Result:", json);

--- a/src/components/Transaction/index.tsx
+++ b/src/components/Transaction/index.tsx
@@ -5,10 +5,9 @@ import Link from "next/link";
 import { type FC } from "react";
 import { TransactionView } from "../TransactionView";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import getTransaction from "./getTransaction";
+import { getTransaction } from "./getTransaction";
 
 interface TransactionProps {
-  // txData: TransactionDataPayload
   endpoint: string,
   queryName: string,
   hash: string,

--- a/src/components/Transaction/index.tsx
+++ b/src/components/Transaction/index.tsx
@@ -1,19 +1,26 @@
-import { type TransactionResultPayload } from "@/lib/validators/search";
+"use client";
 import { JsonView, allExpanded, defaultStyles } from "react-json-view-lite";
 import "react-json-view-lite/dist/index.css";
 import Link from "next/link";
 import { type FC } from "react";
 import { TransactionView } from "../TransactionView";
-import { ibcRegistry } from "@/lib/protobuf";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import getTransaction from "./getTransaction";
 
 interface TransactionProps {
-  txData: TransactionResultPayload
+  // txData: TransactionDataPayload
+  endpoint: string,
+  queryName: string,
+  hash: string,
 }
 
-const Transaction : FC<TransactionProps> = ({ txData }) => {
-  const [txResult, penumbraTx] = txData;
-  // const abciEvents = txResult.events;
+export const Transaction : FC<TransactionProps> = ({ endpoint, queryName, hash }) => {
+  const { data } = useSuspenseQuery({
+    queryKey: [queryName, hash],
+    queryFn: () => getTransaction({ endpoint, hash }),
+  });
 
+  const [ txResult, penumbraTx ] = data;
   return (
     <div>
       <div className="flex flex-wrap justify-between sm:p-5 p-2 sm:gap-y-10 gap-y-5 w-full">
@@ -34,7 +41,7 @@ const Transaction : FC<TransactionProps> = ({ txData }) => {
         <div className="flex flex-wrap justify-start w-full">
           <p className="sm:w-1/6 sm:shrink-0 w-full sm:text-lg font-semibold">Transaction Data</p>
           <pre className="sm:w-5/6 w-full break-all whitespace-pre-wrap text-xs p-1 bg-slate-100">
-            <JsonView data={penumbraTx.toJson({ typeRegistry: ibcRegistry }) as object} shouldExpandNode={allExpanded} clickToExpandNode={true} style={defaultStyles}/>
+            <JsonView data={penumbraTx as object} shouldExpandNode={allExpanded} clickToExpandNode={true} style={defaultStyles}/>
           </pre>
         </div>
         <TransactionView tx={penumbraTx}/>
@@ -42,5 +49,3 @@ const Transaction : FC<TransactionProps> = ({ txData }) => {
     </div>
   );
 };
-
-export default Transaction;

--- a/src/components/TransactionView/index.tsx
+++ b/src/components/TransactionView/index.tsx
@@ -1,9 +1,10 @@
 import { type FC } from "react";
-import { TransactionView as TransactionViewSchema, type Transaction, TransactionBodyView as TransactionBodyViewSchema, MemoView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
+import { TransactionView as TransactionViewSchema, Transaction, TransactionBodyView as TransactionBodyViewSchema, MemoView } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { makeActionView } from "@/lib/protobuf";
 import { TransactionBodyView } from "./TransactionBodyView";
 import { FlexRow } from "../ui/flex";
 import { ActionRow } from "../ActionView";
+import { ZodJson } from "@/lib/validators/json";
 
 const BindingSig = ActionRow;
 const MerkleRoot = ActionRow;
@@ -34,11 +35,11 @@ const makeTransactionView = ({ body, ...tx }: Transaction) : TransactionViewSche
 };
 
 interface TransactionViewProps {
-  tx: Transaction
+  tx: ZodJson
 }
 
 export const TransactionView : FC<TransactionViewProps> = ({ tx }) => {
-  const txView = makeTransactionView(tx);
+  const txView = makeTransactionView(Transaction.fromJson(tx));
   return (
     <FlexRow className="flex-wrap justify-start w-full">
       <p className="font-semibold sm:text-lg">Transaction View</p>

--- a/src/components/TransactionsTable/getTransactions.ts
+++ b/src/components/TransactionsTable/getTransactions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { TransactionsTableData } from "@/lib/validators/table";
 
 export default async function getTransactions({ endpoint, pageIndex } : { endpoint: string, pageIndex: number}) {

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -32,7 +32,7 @@ export function TransactionsTable ({
   const [pagination, setPagination] = useState<PaginationState>({...defaultQueryOptions});
 
   const { data } = useSuspenseQuery({
-    queryKey: [queryName, pagination],
+    queryKey: [queryName, pagination.pageIndex],
     queryFn: () => getTransactions({ endpoint, pageIndex: pagination.pageIndex }),
     meta: {
       errorMessage,

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -1,67 +1,60 @@
+"use client";
+
 import { columns } from "./columns";
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { PaginatedDataTable } from "../ui/paginated-data-table";
 import getTransactions from "./getTransactions";
+import { useState } from "react";
+import { PaginationState, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { cn } from "@/lib/utils";
 
-// TODO: resolve these typings and that with zod and how to navigate between them.
-// NOTE: is it possible to derive a tuple type that encodes the valid combinations of event attributes and their types?
-export type TransactionType = "tx" | "action_spend" | "action_output" | "action_delegate" | "action_undelegate" | "action_position_open"| "action_postion_close" | "action_swap" | "action_swap_claim" | "action_position_withdraw" | "action_spend" ;
-
-export type TransactionKey = "amount" | "hash" | "height" | "note_commitment" | "nullifier" | "position_id" | "reserves_1" | "reserves_2" | "trading_fee" | "trading_p1" | "trading_p2" | "trading_pair" | "validator";
-
-export interface Attribute {
-  key: TransactionKey,
-  value: string | number,
+export interface QueryOptions {
+  pageIndex: number,
+  pageSize: number,
 }
 
-export interface Event {
-  type: TransactionType,
-  attributes: Attribute[],
+interface PaginatedDataTableProps {
+  className?: string,
+  queryName: string,
+  defaultQueryOptions: QueryOptions,
+  endpoint: string,
+  errorMessage: string,
 }
 
-export interface TransactionResult {
-  height: number,
-  createdAt: Date,
-  chain_id: string,
-  hash: string,
-  // TODO: is string actually wanted here for the representation of this buffer
-  result: string,
-  events: Event[],
-};
+export function TransactionsTable ({
+  className,
+  queryName,
+  defaultQueryOptions,
+  endpoint,
+  errorMessage,
+} : PaginatedDataTableProps) {
 
-// TODO: Could try extracting out a minimal data table representation that can then be modified for different query types
-//       such as Blocks vs Block Events vs Transaction Results vs Transaction Events etc.
-const TransactionsTable = async ({ className } : { className?: string })  => {
-  const queryClient = new QueryClient();
+  const [pagination, setPagination] = useState<PaginationState>({...defaultQueryOptions});
 
-  const defaultQueryOptions = {
-    pageIndex: 0,
-    pageSize: 10,
-  };
-
-  const endpoint = "/api/transactions";
-  const queryName = "TransactionsTable";
-  const errorMessage = "Failed to query data while trying to generate event table, please try reloading the page.";
-  await queryClient.prefetchQuery({
-    queryFn: async () => await getTransactions({ endpoint, pageIndex: 0}),
-    queryKey: [queryName, defaultQueryOptions],
+  const { data } = useSuspenseQuery({
+    queryKey: [queryName, pagination],
+    queryFn: () => getTransactions({ endpoint, pageIndex: pagination.pageIndex }),
     meta: {
       errorMessage,
     },
   });
 
+  const { pages: pageCount, results: tableData } = data ?? { pages: 0, results: []};
+
+  const table = useReactTable({
+    data: tableData,
+    columns,
+    pageCount,
+    state: {
+      pagination,
+    },
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <PaginatedDataTable
-        className={className}
-        queryName={queryName}
-        defaultQueryOptions={defaultQueryOptions}
-        columns={columns}
-        endpoint={endpoint}
-        fetcher={getTransactions}
-        errorMessage={errorMessage}/>
-    </HydrationBoundary>
+    <div className={cn(className)} >
+      <PaginatedDataTable table={table} columns={columns}/>
+    </div>
   );
 };
-
-export default TransactionsTable;

--- a/src/components/ui/paginated-data-table.tsx
+++ b/src/components/ui/paginated-data-table.tsx
@@ -61,7 +61,7 @@ export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
     pageSize,
   };
 
-  const { data } = useQuery({
+  const { data, isError, isPending, isSuccess } = useQuery({
     queryKey: [queryName, queryOptions],
     queryFn: async () => await fetcher({ endpoint, pageIndex }),
     meta: {
@@ -91,70 +91,87 @@ export function PaginatedDataTable<TData, TValue, Z extends z.ZodTypeAny>({
     manualPagination: true,
   });
 
-  return (
-    <div className={`${className ?? ""}`}>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
+  if (isSuccess){
+    return (
+      <div className={`${className ?? ""}`}>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    );
+                  })}
                 </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows?.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    data-state={row.getIsSelected() && "selected"}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        <div className="flex items-center justify-end space-x-2 py-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {table.previousPage()}}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {table.nextPage()}}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+       </div>
+    );
+  }
+  if (isPending) {
+    return (
+      <div className="rounded-sm shadow-md">
+        <h1 className="text-lg font-semibold">Loading...</h1>
       </div>
-      <div className="flex items-center justify-end space-x-2 py-4">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {table.previousPage()}}
-          disabled={!table.getCanPreviousPage()}
-        >
-          Previous
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {table.nextPage()}}
-          disabled={!table.getCanNextPage()}
-        >
-          Next
-        </Button>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-sm shadow-md py-5 flex justify-center">
+        <h1 className="text-lg font-semibold">No results found.</h1>
       </div>
-     </div>
-  );
+    );
+  }
 }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,73 @@
+import { toast } from "@/components/ui/use-toast";
+import { QueryCache, QueryClient, defaultShouldDehydrateQuery, isServer } from "@tanstack/react-query";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
- 
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+const makeQueryClient = () => {
+  // const { toast } = useToast();
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Direct suggestion by tanstack, to prevent over-eager refetching from the client.
+        staleTime: 60 * 1000,
+      },
+      dehydrate: {
+        // only successful and pending Queries are included per defaults
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+    },
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        // TODO: Overall model is fine but need to change how meta is used.
+        // Idea: Add a `errorTitle` field instead that can be used in place of "Error" below. This gives a top level, succinct explanation.
+        //       `description` becomes whatever value we store inside our error value. This is what needs to be refactored to make all queries play nicely.
+        //       This allows each error to clearly signal its nature while also giving detail where appropriate. The issue of that detail is delegated to the useQuery callsite
+        //       and any component/route that throws errors.
+        // There may be a more elegant way of expressing this but the general typing of onError's `error` and `query` arguments requires some amount of refinement for safety.
+        // https://tanstack.com/query/latest/docs/react/reference/QueryCache
+        let errorMessage = "";
+        const meta = query?.meta ?? undefined ;
+        if (meta) {
+          // Precondition for this type cast: meta is of type Record<string, unknown> where any query with a meta object containing the property `errorMessage` has a value of type string.
+          errorMessage = meta?.errorMessage as string ?? "";
+        }
+        if (errorMessage !== "") {
+          toast({
+            variant: "destructive",
+            title: "Error",
+            description: `${errorMessage}`,
+          });
+        } else {
+          // TODO: Realistically, this will not be a useful error and should be improved further.
+          toast({
+            variant: "destructive",
+            title: "Error",
+            description: `${error.message}`,
+          });
+        }
+      },
+    }),
+  });
+};
+
+export const getQueryClient = () => {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+};

--- a/src/lib/validators/json.ts
+++ b/src/lib/validators/json.ts
@@ -9,3 +9,5 @@ type Json = Literal | { [key: string]: Json } | Json[];
 export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)]),
 );
+
+export type ZodJson = z.infer<typeof jsonSchema>;

--- a/src/lib/validators/search.ts
+++ b/src/lib/validators/search.ts
@@ -1,7 +1,5 @@
-import { Transaction } from "@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/transaction/v1/transaction_pb";
 import { z } from "zod";
 import { jsonSchema } from "./json";
-import { ibcRegistry } from "../protobuf";
 
 // This validator is to check whether a sha256 hash conforms to what is expected by the `tx_hash` column
 // of the `tx_result` table defined in cometbft's psql indexer schema.
@@ -130,14 +128,15 @@ const EventAttribute = z.array(
 );
 
 // zod schema equivalent to the /parsed/ JSON data returned by GET /api/transaction?q=<hash>
-export const TransactionResult = z.tuple([
+export const TransactionData = z.tuple([
   z.object({
     tx_hash: z.string(),
     height: z.coerce.bigint(),
     created_at: z.string().datetime(),
     events: jsonSchema.pipe(EventAttribute),
   }),
-  jsonSchema.transform((json) => Transaction.fromJson(json, { typeRegistry: ibcRegistry })),
+  jsonSchema,
+  // jsonSchema.transform((json) => Transaction.fromJson(json, { typeRegistry: ibcRegistry })),
 ]);
 
 // Schema for JSON data by GET /api/block?q=<height>
@@ -198,5 +197,5 @@ export const BlockData = z.array(
   return { tx_hashes, created_at, events };
 });
 
-export type TransactionResultPayload = z.infer<typeof TransactionResult>;
+export type TransactionDataPayload = z.infer<typeof TransactionData>;
 export type BlockDataPayload = z.infer<typeof BlockData>;


### PR DESCRIPTION
Part of #32, #40, #17, #124, and #129 

# Summary

This PR added:
- a basic skeleton component
- `React.Suspense` + tanstack useSuspenseQuery support to:
  +  `/block/[ht]`
  + `/transaction/[hash]`
  + `/blocks`
  + `/transactions`
- Fixing a pretty big bug with how tanstack was querying and caching some routes because of incorrect suspense docs
- prefetching to `/block` and `/transaction`
- Reworked `paginated-data-table.tsx` component and how `TransactionsTable` and `BlocksTable` consume it + use tanstack/table

This PR was painful. A lot of small logistical stuff with how queries were structured and used + poor documentation but the UX/UI of the client has benefited greatly from it. 
