### PR TITLE
build: default to localhost for grpc url

### DIFF
--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -14,7 +14,7 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 }
 
 const penumbraTransport = createGrpcWebTransport({
-  baseUrl: "https://grpc.testnet.penumbra.zone",
+  baseUrl: process.env.PENUMBRA_GRPC_ENDPOINT ? process.env.PENUMBRA_GRPC_ENDPOINT : "http://localhost:8080",
 });
 
 


### PR DESCRIPTION
The old FQDN that was hardcoded in the constants file doesn't exist anymore. Let's:

  * default to localhost:8080
  * enable overrides via env var

That should allow customization for different testing and deploy contexts.