### PR TITLE
Update fetching to use `env.process` when available

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -3,8 +3,8 @@ import { getPgClient } from "@/lib/db";
 import { sql } from "@pgtyped/runtime";
 import { IGetTransactionsCountQuery, IGetTransactionsQuery } from "./route.types";
 
-export async function POST(req: Request) {
-  console.log("Success: POST /api/transactions");
+export async function GET(req: Request) {
+  console.log("Success: GET /api/transactions");
   try {
     const url = new URL(req.url);
     const pageParam = url.searchParams.get("page")?.trim() ?? "";

--- a/src/app/block/[ht]/page.tsx
+++ b/src/app/block/[ht]/page.tsx
@@ -14,7 +14,7 @@ const Page : FC<PageProps> = ({ params }) => {
 
   const queryClient = getQueryClient();
 
-  const endpoint = "/api/block/";
+  const endpoint = "api/block/";
   const queryName = "htQuery";
   const errorMessage = "Failed to query block with provided height, please check height or try a different query";
 

--- a/src/app/blocks/page.tsx
+++ b/src/app/blocks/page.tsx
@@ -14,7 +14,7 @@ const Page = () => {
   };
 
   const queryName = "BlocksTable";
-  const endpoint = "/api/blocks";
+  const endpoint = "api/blocks";
   const errorMessage = "Failed to query data while trying to generate blocks table, please try reloading the page.";
 
   queryClient.prefetchQuery({

--- a/src/app/ibc/channel/[id]/page.tsx
+++ b/src/app/ibc/channel/[id]/page.tsx
@@ -14,7 +14,7 @@ const Page : FC<PageProps> = ({ params }) => {
   const { id: channelId } = params;
   const queryClient = getQueryClient();
 
-  const endpoint = "/api/ibc/channel";
+  const endpoint = "api/ibc/channel";
   const queryName = "IbcChannel";
   const errorMessage = "Failed to query IBC Channel by id. Please try again.";
   queryClient.prefetchQuery({

--- a/src/app/ibc/channels/page.tsx
+++ b/src/app/ibc/channels/page.tsx
@@ -12,7 +12,7 @@ const Page = () => {
     pageSize: 0,
   };
 
-  const endpoint = "/api/ibc/channels";
+  const endpoint = "api/ibc/channels";
   const queryName = "IbcChannels";
   const errorMessage = "Failed to query for IBC Channels. Please try again.";
 

--- a/src/app/ibc/client/[id]/page.tsx
+++ b/src/app/ibc/client/[id]/page.tsx
@@ -14,7 +14,7 @@ const Page : FC<PageProps> = ({ params }) => {
   const { id: clientId } = params;
   const queryClient = getQueryClient();
 
-  const endpoint = "/api/ibc/client";
+  const endpoint = "api/ibc/client";
   const queryName = "IbcClient";
   const errorMessage = "Failed to query IBC Client by id. Please try again.";
   queryClient.prefetchQuery({

--- a/src/app/ibc/clients/page.tsx
+++ b/src/app/ibc/clients/page.tsx
@@ -12,7 +12,7 @@ const Page = () => {
     pageSize: 0,
   };
 
-  const endpoint = "/api/ibc/clients";
+  const endpoint = "api/ibc/clients";
   const queryName = "IbcClients";
   const errorMessage = "Failed to query for IBC Clients. Please try again.";
 

--- a/src/app/ibc/connection/[id]/page.tsx
+++ b/src/app/ibc/connection/[id]/page.tsx
@@ -15,7 +15,7 @@ const Page : FC<PageProps> = ({ params }) => {
 
   const queryClient = getQueryClient();
 
-  const endpoint = "/api/ibc/connection";
+  const endpoint = "api/ibc/connection";
   const queryName = "IbcConnection";
   const errorMessage = "Failed to query IBC Connection by id. Please try again.";
   queryClient.prefetchQuery({

--- a/src/app/ibc/connections/page.tsx
+++ b/src/app/ibc/connections/page.tsx
@@ -12,7 +12,7 @@ const Page = () => {
     pageSize: 0,
   };
 
-  const endpoint = "/api/ibc/connections";
+  const endpoint = "api/ibc/connections";
   const queryName = "IbcConnections";
   const errorMessage = "Failed to query for IBC Connections. Please try again.";
 

--- a/src/app/transaction/[hash]/page.tsx
+++ b/src/app/transaction/[hash]/page.tsx
@@ -15,7 +15,7 @@ const Page : FC<PageProps> = ({ params }) => {
 
   const queryClient = getQueryClient();
 
-  const endpoint = "/api/transaction/";
+  const endpoint = "api/transaction/";
   const queryName = "txQuery";
   const errorMessage = "Failed to query transaction, please try reloading the page.";
 

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -14,7 +14,7 @@ const Page = () => {
     pageSize: 10,
   };
 
-  const endpoint = "/api/transactions";
+  const endpoint = "api/transactions/";
   const queryName = "TransactionsTable";
   const errorMessage = "Failed to query data while trying to generate event table, please try reloading the page.";
 

--- a/src/components/Block/getBlock.ts
+++ b/src/components/Block/getBlock.ts
@@ -1,8 +1,10 @@
+import { getBaseURL } from "@/lib/utils";
 import { BlockData } from "@/lib/validators/search";
 
 export async function getBlock({ endpoint, ht } : { endpoint: string, ht: string}) {
-  console.log(`Fetching: GET ${endpoint}?q=${ht}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?q=${ht}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?q=${ht}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?q=${ht}`, { method: "GET" });
   const json = await res.json();
   console.log("Fetched Result:", json);
   const result = BlockData.safeParse(json);

--- a/src/components/BlocksTable/getBlocks.ts
+++ b/src/components/BlocksTable/getBlocks.ts
@@ -1,8 +1,10 @@
+import { getBaseURL } from "@/lib/utils";
 import { BlocksTableQuery } from "@/lib/validators/table";
 
 export async function getBlocks ({ endpoint, pageIndex } : ({ endpoint: string, pageIndex: number })) {
-  console.log(`Fetching: POST ${endpoint}?page=${pageIndex}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "POST" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: POST ${baseUrl}/?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "POST" });
   const json = await res.json();
 
   console.log("Fetched result:", json);

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -2,20 +2,17 @@
 
 import React, { useState } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { TransportProvider } from "@connectrpc/connect-query";
 import { Toaster } from "../ui/toaster";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { type ThemeProviderProps } from "next-themes/dist/types";
-import { getQueryClient } from "@/lib/utils";
+import { getQueryClient, penumbraTransport } from "@/lib/utils";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }
 
-const penumbraTransport = createGrpcWebTransport({
-  baseUrl: process.env?.PENUMBRA_GRPC_ENDPOINT ?? "http://localhost:8080",
-});
+
 
 
 const Providers = ({ children } : { children: React.ReactNode }) => {

--- a/src/components/Transaction/getTransaction.ts
+++ b/src/components/Transaction/getTransaction.ts
@@ -1,8 +1,10 @@
+import { getBaseURL } from "@/lib/utils";
 import { TransactionData } from "@/lib/validators/search";
 
 export async function getTransaction({ endpoint, hash } : { endpoint: string, hash: string}) {
-  console.log(`Fetching: GET ${endpoint}?q=${hash}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?q=${hash}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?q=${hash}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?q=${hash}`, { method: "GET" });
   const json = await res.json();
   console.log("Fetched Result:", json);
   const result = TransactionData.safeParse(json);

--- a/src/components/TransactionsTable/getTransactions.ts
+++ b/src/components/TransactionsTable/getTransactions.ts
@@ -1,8 +1,10 @@
+import { getBaseURL } from "@/lib/utils";
 import { TransactionsTableData } from "@/lib/validators/table";
 
 export async function getTransactions({ endpoint, pageIndex } : { endpoint: string, pageIndex: number}) {
-  console.log(`Fetching: POST ${endpoint}?page=${pageIndex}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "POST" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: POST ${baseUrl}/${endpoint}?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "GET" });
   const json = await res.json();
   console.log("Fetched Result:", json);
   const result = TransactionsTableData.safeParse(json);

--- a/src/components/ibc/Channel/getIbcChannel.ts
+++ b/src/components/ibc/Channel/getIbcChannel.ts
@@ -1,5 +1,8 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcChannel({ endpoint, channelId } : { endpoint: string, channelId: string}) {
-  console.log(`Fetching: GET ${endpoint}?q=${channelId}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?q=${channelId}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?q=${channelId}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?q=${channelId}`, { method: "GET" });
   return await res.json();
 }

--- a/src/components/ibc/Client/getIbcClient.ts
+++ b/src/components/ibc/Client/getIbcClient.ts
@@ -1,5 +1,8 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcClient ({ endpoint, clientId } : { endpoint: string, clientId: string }) {
-  console.log(`Fetching: GET ${endpoint}?q=${clientId}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?q=${clientId}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?q=${clientId}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?q=${clientId}`, { method: "GET" });
   return await res.json();
 }

--- a/src/components/ibc/Connection/getIbcConnection.ts
+++ b/src/components/ibc/Connection/getIbcConnection.ts
@@ -1,5 +1,8 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcConnection ({ endpoint, connectionId } : { endpoint: string, connectionId: string }) {
-  console.log(`Fetching: GET ${endpoint}?q=${connectionId}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?q=${connectionId}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?q=${connectionId}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?q=${connectionId}`, { method: "GET" });
   return await res.json();
 }

--- a/src/components/ibc/channels/getIbcChannels.ts
+++ b/src/components/ibc/channels/getIbcChannels.ts
@@ -1,6 +1,9 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcChannels({ endpoint, pageIndex } : { endpoint: string, pageIndex: number}) {
-  console.log(`Fetching: GET ${endpoint}?page=${pageIndex}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "GET" });
   return await res.json();
   // const result = ChannelsTableData.safeParse(json);
   // if (result.success) {

--- a/src/components/ibc/clients/getIbcClients.ts
+++ b/src/components/ibc/clients/getIbcClients.ts
@@ -1,6 +1,9 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcClients({ endpoint, pageIndex } : { endpoint: string, pageIndex: number }) {
-  console.log(`Fetching: GET ${endpoint}?page=${pageIndex}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "GET" });
   const json = await res.json();
   return json;
 }

--- a/src/components/ibc/connections/getIbcConnections.ts
+++ b/src/components/ibc/connections/getIbcConnections.ts
@@ -1,5 +1,8 @@
+import { getBaseURL } from "@/lib/utils";
+
 export async function getIbcConnections({ endpoint, pageIndex } : { endpoint: string, pageIndex: number}) {
-  console.log(`Fetching: GET ${endpoint}?page=${pageIndex}`);
-  const res = await fetch(`http://localhost:3000${endpoint}?page=${pageIndex}`, { method: "GET" });
+  const baseUrl = getBaseURL();
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "GET" });
   return await res.json();
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { toast } from "@/components/ui/use-toast";
+import { createGrpcWebTransport } from "@connectrpc/connect-web";
 import { QueryCache, QueryClient, defaultShouldDehydrateQuery, isServer } from "@tanstack/react-query";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
@@ -71,3 +72,19 @@ export const getQueryClient = () => {
     return browserQueryClient;
   }
 };
+
+
+export const penumbraTransport = createGrpcWebTransport({
+  baseUrl: process.env.PENUMBRA_GRPC_ENDPOINT ?? "http://localhost:8080",
+});
+
+
+export function getBaseURL() {
+  if (!isServer) {
+    return "";
+  }
+  if (process?.env?.APP_URL !== undefined) {
+    return `${process.env.APP_URL}`;
+  }
+  return "http://localhost:3000";
+}


### PR DESCRIPTION
# Summary

Can now add `APP_URL` to a `.env` file and fetching will respect it.

```sh
# .env file
PORT=3131
APP_URL=http://localhost:$PORT
```
Will result in Cuiloa deploying on localhost:3131 and with all fetch requests will use the env value when available (on server)