### PR TITLE
Updated landing page for redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/api/blocks/route.ts
+++ b/src/app/api/blocks/route.ts
@@ -3,8 +3,8 @@ import { sql } from "@pgtyped/runtime";
 import { IGetBlocksByDescQuery, IGetBlocksCountQuery} from "./route.types";
 import { getPgClient } from "@/lib/db";
 
-export async function POST(req: Request) {
-  console.log("POST req on /api/blocks/");
+export async function GET(req: Request) {
+  console.log("GET req on /api/blocks/");
   try {
     const url = new URL(req.url);
     const pageParam = url.searchParams.get("page")?.trim() ?? "";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,18 +32,16 @@ export default function RootLayout({
       <body className="bg-gradient-repeat-radial min-w-full min-h-screen">
         <Providers>
           <Navbar />
-          <div className="flex flex-col container xs-container justify-start min-h-[640px]">
-            <div className="p-1 sm:p-2 mb-auto">
-              {children}
-            </div>
-            <div className="self-center py-5">
-              <Link href="https://github.com/penumbra-zone/cuiloa">
-                <CodeIcon className="w-4" />
-              </Link>
-            </div>
+          <div className="container xs-container justify-start min-h-[640px]">
+            {children}
           </div>
           <ReactQueryDevtools initialIsOpen={false} />
         </Providers>
+        <div className="flex flex-col justify-center items-center h-full">
+          <Link href="https://github.com/penumbra-zone/cuiloa">
+            <CodeIcon className="w-4" />
+          </Link>
+        </div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,55 +2,88 @@ import Link from "next/link";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
 
 import { Button } from "@/components/ui/button";
+import { FC } from "react";
+
+interface CardProps {
+  buttonText: string,
+  buttonLink: string,
+  children?: React.ReactNode,
+  className?: string,
+  heading: string,
+}
+
+const LandingCard: FC<CardProps> = ({ heading, children, className, buttonText, buttonLink }) => {
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle className="text-lg font-medium">{heading}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1 items-center w-full">
+        {children}
+        <Button className="w-full" asChild>
+          <Link href={buttonLink}>{buttonText}</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
 
 export default async function Home() {
-  // Idea: break out the buttons to their own cards where each uses the description to help describe the data to users.
   return (
-    <div className="flex gap-5 items-center justify-center py-5">
-      <div>
-        <Card>
-          <CardHeader className="">
-            <CardTitle className="text-center text-lg sm:text-2xl">
-              Penumbra is constantly evolving...
-            </CardTitle>
-            <CardDescription className="text-center">
-              Navigate and explore public chain data with the links below.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-col gap-1 items-center">
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/transactions">Recent Transactions</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/blocks">Recent Blocks</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/ibc/clients">IBC Clients</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/ibc/channels">IBC Channels</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/ibc/connections">IBC Connections</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/staking">Staking</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/dex">Dex</Link>
-            </Button>
-            <Button className="sm:w-2/3 w-full" asChild>
-              <Link href="/governance">Governance</Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
+    <div className="flex flex-wrap gap-3 items-center justify-between py-5">
+      <LandingCard
+        heading="Transactions"
+        buttonLink="/transactions"
+        buttonText="Explore Transactions"
+        className="basis-[45%] w-auto"
+      />
+      <LandingCard
+        heading="Blocks"
+        buttonLink="/blocks"
+        buttonText="Explore Blocks"
+        className="basis-[45%] w-auto"
+      />
+      <LandingCard
+        heading="IBC Clients"
+        buttonLink="/ibc/clients"
+        buttonText="Explore Clients"
+        className="w-[380px]"
+      />
+      <LandingCard
+        heading="IBC Connections"
+        buttonLink="/ibc/connections"
+        buttonText="Explore Connections"
+        className="w-[380px]"
+      />
+      <LandingCard
+        heading="IBC Channels"
+        buttonLink="/ibc/channels"
+        buttonText="Explore Channels"
+        className="w-[380px]"
+      />
+      <LandingCard
+        heading="Staking"
+        buttonLink="/staking"
+        buttonText="Explore Staking"
+        className="w-[380px]"
+      />
+      <LandingCard
+        heading="Dex"
+        buttonLink="/dex"
+        buttonText="Explore Dex"
+        className="w-[380px]"
+      />
+      <LandingCard
+        heading="Governance"
+        buttonLink="/governance"
+        buttonText="Explore Governance"
+        className="w-[380px]"
+      />
     </div>
   );
 }

--- a/src/components/BlocksTable/getBlocks.ts
+++ b/src/components/BlocksTable/getBlocks.ts
@@ -3,8 +3,8 @@ import { BlocksTableQuery } from "@/lib/validators/table";
 
 export async function getBlocks ({ endpoint, pageIndex } : ({ endpoint: string, pageIndex: number })) {
   const baseUrl = getBaseURL();
-  console.log(`Fetching: POST ${baseUrl}/?page=${pageIndex}`);
-  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "POST" });
+  console.log(`Fetching: GET ${baseUrl}/${endpoint}/?page=${pageIndex}`);
+  const res = await fetch(`${baseUrl}/${endpoint}?page=${pageIndex}`, { method: "GET" });
   const json = await res.json();
 
   console.log("Fetched result:", json);

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { ThemeToggleButton } from "../ThemeToggleButton";
 import radiantLogoRainbow from "./radiant-logo-rainbow.png";
+import radiantLogoBw from "./radiant-logo-bw.png";
 import { workSans } from "@/app/fonts";
 
 const RadiantLogoRainbow = ({ width, height, className } : { width: number, height: number, className?: string }) => {
@@ -16,12 +17,21 @@ const RadiantLogoRainbow = ({ width, height, className } : { width: number, heig
   );
 };
 
+const RadiantLogoBw = ({ width, height, className } : { width: number, height: number, className?: string }) => {
+  return (
+    <div className={className}>
+      <Image src={radiantLogoBw} alt="RadiantCommons.com Logo" width={width} height={height}/>
+    </div>
+  );
+};
+
 export const Navbar : FC = () => {
   return (
-  <div className="flex justify-between items-center py-8 max-w-[1200px] mx-auto">
-    <div className="flex-grow flex flex-wrap items-baseline">
+  <div className="flex justify-between items-center p-8 max-w-[1400px] mx-auto">
+    <div className="flex-grow flex flex-wrap items-center">
       <Link href="https://radiantcommons.com" className="self-center" >
-        <RadiantLogoRainbow height={24} width={24}/>
+        <RadiantLogoRainbow height={48} width={48} className="dark:block hidden"/>
+        <RadiantLogoBw height={48} width={48} className="dark:hidden "/>
       </Link>
       <h1 className={`font-semibold text-2xl ml-1 mr-3 ${workSans.className}`}><Link href="/">Cuiloa</Link></h1>
       <Link className={`text-link font-medium font-display ${workSans.className}`} href="https://penumbra.zone/">

--- a/src/components/PreviewTable/index.tsx
+++ b/src/components/PreviewTable/index.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { columns as blocksColumns} from "@/components/BlocksTable/columns";
+import { columns as transactionsColumns } from "@/components/TransactionsTable/columns";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { DataTable } from "../ui/data-table";
+import { getBlocks } from "@/components/BlocksTable/getBlocks";
+import { getTransactions } from "../TransactionsTable/getTransactions";
+import { cn } from "@/lib/utils";
+
+export interface QueryOptions {
+  pageIndex: number,
+  pageSize: number,
+}
+
+interface PreviewTableProps {
+  className?: string,
+  queryName: "previewBlocks" | "previewTransactions",
+  pageIndex: number,
+  endpoint: string,
+  errorMessage: string,
+}
+
+// TODO: Unbelievably gross stuff that needs to be parameterized later.
+// TODO: It would be nice to have a tagged union type that allows narrowing instead of all the gross stuff up to this point.
+//       In addition to that, however, is the need to resolve the slices below. The current APIs do an integer check for offsets
+//       that prevent values below 10. It really shouldn't be an issue but it would be nice to do something better than this.
+export function PreviewTable ({
+  className,
+  queryName,
+  pageIndex = 0,
+  endpoint,
+  errorMessage,
+} : PreviewTableProps) {
+
+  const getFn  = queryName === "previewBlocks" ? getBlocks : getTransactions;
+
+  const { data } : {
+    data : {
+      pages: number;
+      results: {
+        height: bigint;
+        created_at: string;
+      }[];
+    } | {
+      pages: number;
+      results: {
+        height: bigint;
+        created_at: string;
+        tx_hash: string;
+      }[];
+    }
+  } = useSuspenseQuery({
+    queryKey: [queryName],
+    queryFn: () => getFn({ endpoint, pageIndex }),
+    meta: {
+      errorMessage,
+    },
+  });
+
+  const { results } = data ?? { pages: 0, results: []};
+
+  // Checks only necessary for safely enforcing type. See todo comment above.
+  if (queryName === "previewBlocks") {
+    const tableData = results as {
+      height: bigint,
+      created_at: string,
+    }[];
+
+    return (
+      <div className={cn("", className)}>
+        <DataTable data={tableData.slice(0,3)} columns={blocksColumns}/>
+      </div>
+    );
+  } else {
+
+    const tableData = results as {
+      height: bigint,
+      created_at: string,
+      tx_hash: string
+    }[];
+
+    return (
+      <div className={cn("overflow-auto", className)}>
+        <DataTable data={tableData.slice(0,3)} columns={transactionsColumns}/>
+      </div>
+    );
+  }
+};

--- a/src/components/Providers/index.tsx
+++ b/src/components/Providers/index.tsx
@@ -12,9 +12,6 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }
 
-
-
-
 const Providers = ({ children } : { children: React.ReactNode }) => {
   // NOTE: there is a very explicit warning in the TanStack docs about using useState for handling QueryClient (de)hydration within the provider in the scenario where
   //       there is no Suspense boundary between the instantiation (here) and the context that is being wrapped; however, it is more or less considered best practice to

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -16,6 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/Table";
+import { cn } from "@/lib/utils";
 
 interface DataTableProps<TData, TValue> {
   className?: string,
@@ -41,51 +42,49 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className={`${className ?? ""}`}>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
+    <div className={cn("rounded-md border", className)}>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="p-3">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
               </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="p-3">
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="h-24 text-center">
-                  No results.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
     </div>
   );
 }


### PR DESCRIPTION
Closes #65 

This PR updates the landing page to match those in the mocks. Added a `PreviewTable` component that provides a convenient wrapper for the un-paginated data-table ui components.

Caught an extremely obnoxious bug that only seems to exist in dev mode, on chrome, when not using `--turbo` as a feature, and when loading an initial page with a `Suspense` boundary on it (in this PR, `HydrationBoundary`). The update to the dev command should prevent this in the future.

This bug is a `SyntaxError` for the initial load of layout.tsx that only points to the minified webpack string. This eventually triggers a random hard runtime error that crashes the page because a chunk failed to load from `.next` after a minute or two. 

From my own testing, it does not appear to emerge in any production builds but this PR is a convenient place to note the behavior in case the bug emerges again.