### PR TITLE
default not-found and error pages for cuiloa

### DIFF
--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,36 @@
+// NOTE: Must be client component. Them's the rules.
+// https://nextjs.org/docs/app/building-your-application/routing/error-handling#using-error-boundaries
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+     console.error(error);
+  }, [error]);
+
+  return (
+    <div className="bg-primary/60 py-8 rounded-lg border">
+      <div className="flex flex-col gap-8 items-center">
+        <h1 className="text-lg font-medium sm:w-11/12 w-full">An error has occurred.</h1>
+        <p className="text-sm sm:w-11/12 w-full">Apologies, but something happened with Cuiloa and the client couldn&apos;t recover.</p>
+        <div className="flex sm:w-11/12 w-full gap-8">
+          <Button className="w-fit" asChild>
+            <Link href={"/"}>Home</Link>
+          </Button>
+          <Button className="w-fit" onClick={() => reset()}>
+            Try Reloading
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="bg-primary/60 py-8 rounded-lg border">
+      <div className="flex flex-col gap-8 items-center">
+        <h1 className="text-lg font-medium sm:w-11/12 w-full">Page not found!</h1>
+        <p className="text-sm sm:w-11/12 w-full">Apologies, but Cuiloa could not find the page you requested.</p>
+        <div className="flex sm:w-11/12 w-full gap-8">
+          <Button className="w-fit" asChild>
+            <Link href={"/"}>Go Home</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Part of #25

This PR adds `not-found.tsx` and `error.tsx` to the app root `app/` for the entire application. Any unhandled exceptions, i.e. thrown and uncaught errors, will now be handled by `error.tsx`. Similarly, any unknown page requests will be handled by `not-found.tsx`.

More refined handling can be added by adding custom pages at the segment level but I don't see a need for that right now