### PR TITLE
build: add ssl certs for db connections

### DIFF
--- a/apps/web/Containerfile
+++ b/apps/web/Containerfile
@@ -15,7 +15,6 @@ FROM base AS builder
 ENV NEXT_TELEMETRY_DISABLED=1
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine
 # to understand why libc6-compat might be needed.
-RUN apk update
 RUN apk add --no-cache libc6-compat
 # Set working directory
 COPY . /app
@@ -45,6 +44,8 @@ RUN turbo run build --filter=cuiloa-app
 
 # Run container
 FROM alpine AS runner
+# Ensure that SSL certs are present for DB connections
+RUN apk add --no-cache ca-certificates
 WORKDIR /app
 
 # Disable telemetry.

--- a/justfile
+++ b/justfile
@@ -25,8 +25,13 @@ pgtyped-cli:
 update-cometbft-schema:
   curl -o deploy/postgres-cometbft-schema.sql -sSf "https://raw.githubusercontent.com/cometbft/cometbft/v0.37.2/state/indexer/sink/psql/schema.sql"
 
+# Build the webapp container image
 container:
-  podman build -t ghcr.io/penumbra-zone/cuiloa .
+  podman build -t ghcr.io/penumbra-zone/cuiloa -f apps/web/Containerfile .
+
+# Build, then run the webapp container image. Uses local env vars.
+run-container:
+  podman run -e DATABASE_URL -e APP_URL -e PENUMBRA_GRPC_ENDPOINT -p 3000:3000 -it ghcr.io/penumbra-zone/cuiloa
 
 compose:
   docker compose up


### PR DESCRIPTION
Updated the container build strategy to pull in ca-certs in the runtime image. Doing so permits the app to talk to a variety of SSL-required db endpoints.